### PR TITLE
Added option to store all unequiped items

### DIFF
--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -744,7 +744,7 @@ function COMMON.ShowTeamStorageMenu()
 	
 	local storage_choices = { { STRINGS:FormatKey('MENU_STORAGE_STORE'), has_items},
 	{ STRINGS:FormatKey('MENU_STORAGE_TAKE_ITEM'), has_storage},
-	{ STRINGS:FormatKey('MENU_STORAGE_DEPOSIT_ALL'), true},
+	{ STRINGS:FormatKey('MENU_STORAGE_DEPOSIT_ALL'), has_items},
 	{ STRINGS:FormatKey("MENU_STORAGE_MONEY"), true},
 	{ STRINGS:FormatKey("MENU_CANCEL"), true}}
 	UI:BeginChoiceMenu(STRINGS:FormatKey('DLG_WHAT_DO'), storage_choices, 1, 5)

--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -744,9 +744,10 @@ function COMMON.ShowTeamStorageMenu()
 	
 	local storage_choices = { { STRINGS:FormatKey('MENU_STORAGE_STORE'), has_items},
 	{ STRINGS:FormatKey('MENU_STORAGE_TAKE_ITEM'), has_storage},
+	{ STRINGS:FormatKey('MENU_STORAGE_DEPOSIT_ALL'), true},
 	{ STRINGS:FormatKey("MENU_STORAGE_MONEY"), true},
 	{ STRINGS:FormatKey("MENU_CANCEL"), true}}
-	UI:BeginChoiceMenu(STRINGS:FormatKey('DLG_WHAT_DO'), storage_choices, 1, 4)
+	UI:BeginChoiceMenu(STRINGS:FormatKey('DLG_WHAT_DO'), storage_choices, 1, 5)
 	UI:WaitForChoice()
 	local result = UI:ChoiceResult()
 	
@@ -756,10 +757,17 @@ function COMMON.ShowTeamStorageMenu()
 	elseif result == 2 then
 	  UI:WithdrawMenu()
 	  UI:WaitForChoice()
-	elseif result == 3 then
+    elseif result == 3 then
+	    UI:ChoiceMenuYesNo("Are you sure you want to deposit all items?", false);
+	    UI:WaitForChoice()
+	    if UI:ChoiceResult() then
+	         UI:DepositAll()
+	    end
+	elseif result == 4 then
 	  UI:BankMenu()
 	  UI:WaitForChoice()
-	elseif result == 4 then
+	
+	elseif result == 5 then
 	  state = -1
 	end
 	

--- a/Strings/strings.resx
+++ b/Strings/strings.resx
@@ -1398,6 +1398,9 @@
   <data name="MENU_STORAGE_STORE" xml:space="preserve">
     <value>Store Items</value>
     <comment></comment>  </data>
+  <data name="MENU_STORAGE_DEPOSIT_ALL" xml:space="preserve">
+    <value>Deposit All Items</value>
+    <comment></comment> </data>
   <data name="MENU_STORAGE_TAKE_BOX" xml:space="preserve">
     <value>Take Boxes</value>
     <comment></comment>  </data>


### PR DESCRIPTION
For this pull request to work, it requires for [this pull request in Rouge Essence](https://github.com/RogueCollab/RogueEssence/pull/14#issue-1393778145) to be merged.

When talking to the statue, a new option appears, letting you deposit all of your items at once.