### PR TITLE
Add rogue restart string

### DIFF
--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -974,7 +974,8 @@ function COMMON.EndDungeonDay(result, zoneId, structureId, mapId, entryId)
   COMMON.EndDayCycle()
   GAME:EndDungeonRun(result, zoneId, structureId, mapId, entryId, true, true)
   if GAME:InRogueMode() then
-    GAME:RestartToTitle()
+    --This is handled in EndGame in GameProgress.cs
+    --GAME:RestartToTitle()
   else
 	GAME:EnterZone(zoneId, structureId, mapId, entryId)
   end

--- a/Strings/strings.resx
+++ b/Strings/strings.resx
@@ -577,7 +577,7 @@
     <value>The replay went out of sync.[pause=0] Returning to the menu...</value>
     <comment></comment>  </data>
   <data name="DLG_REPLAY_VERIFY_DESYNC" xml:space="preserve">
-    <value>Encountered a desync during replay verification. [pause=0] Returing to the menu ... </value>
+    <value>Encountered a desync during replay verification. [pause=0] Returning to the menu ... </value>
     <comment></comment>  </data>
   <data name="DLG_REPLAY_VERIFY_OK" xml:space="preserve">
     <value>The replay has been verified.</value>
@@ -745,7 +745,7 @@
     <value>Transfer complete!</value>
     <comment></comment>  </data>
   <data name="DLG_TRY_AGAIN_ASK" xml:space="preserve">
-    <value>Would you like to try again?</value>
+    <value>Would you like to try again? This will use your current settings.</value>
     <comment></comment>  </data>
   <data name="DLG_WHAT_DO" xml:space="preserve">
     <value>What will you do?</value>

--- a/Strings/strings.resx
+++ b/Strings/strings.resx
@@ -744,6 +744,9 @@
   <data name="DLG_TRANSFER_COMPLETE" xml:space="preserve">
     <value>Transfer complete!</value>
     <comment></comment>  </data>
+  <data name="DLG_TRY_AGAIN_ASK" xml:space="preserve">
+    <value>Would you like to try again?</value>
+    <comment></comment>  </data>
   <data name="DLG_WHAT_DO" xml:space="preserve">
     <value>What will you do?</value>
     <comment></comment>  </data>


### PR DESCRIPTION
String required by this [PR](https://github.com/RogueCollab/RogueEssence/pull/31) + typo fix

It also removes `GAME:RestartToTitle();` which is now handled by EndGame in the PR above