### PR TITLE
Repeat Song Start on Dungeon

### DIFF
--- a/Data/Script/common.lua
+++ b/Data/Script/common.lua
@@ -216,11 +216,9 @@ function COMMON.ShowDestinationMenu(dungeon_entrances, ground_entrances)
 	if dest.StructID.Segment > -1 then
 	  --pre-loads the zone on a separate thread while we fade out, just for a little optimization
 	  _DATA:PreLoadZone(dest.ID)
-	  SOUND:PlayBGM("", true)
       GAME:FadeOut(false, 20)
 	  GAME:EnterDungeon(dest.ID, dest.StructID.Segment, dest.StructID.ID, dest.EntryPoint, RogueEssence.Data.GameProgress.DungeonStakes.Risk, true, false)
 	else
-	  SOUND:PlayBGM("", true)
       GAME:FadeOut(false, 20)
 	  GAME:EnterZone(dest.ID, dest.StructID.Segment, dest.StructID.ID, dest.EntryPoint)
 	end


### PR DESCRIPTION
Fix for https://github.com/audinowho/PMDODump/issues/272.

If the BGM of the first floor of the dungeon is identical to the BGM of the source zone/ground, the BGM will not change.  If the BGM is different, the BGM will automatically change.