### PR TITLE
Adds visible houses and no house entrances

### DIFF
--- a/Data/Tile/chest_full.json
+++ b/Data/Tile/chest_full.json
@@ -62,7 +62,7 @@
 "$type": "PMDC.Dungeon.ChestEvent, PMDC",
 "ChestAnimation": {
 "AnimIndex": "Chest_Open",
-"FrameTime": 1,
+"FrameTime": 8,
 "StartFrame": -1,
 "EndFrame": -1,
 "AnimDir": -1,

--- a/Data/Tile/chest_full.json
+++ b/Data/Tile/chest_full.json
@@ -59,7 +59,17 @@
 ]
 },
 "Value": {
-"$type": "PMDC.Dungeon.ChestEvent, PMDC"
+"$type": "PMDC.Dungeon.ChestEvent, PMDC",
+"ChestAnimation": {
+"AnimIndex": "Chest_Open",
+"FrameTime": 1,
+"StartFrame": -1,
+"EndFrame": -1,
+"AnimDir": -1,
+"Alpha": 255,
+"AnimFlip": 0
+},
+"ChestEmptyTile": "chest_empty"
 }
 }
 ]


### PR DESCRIPTION
Chest full now passes its empty sprite and animation to the ChestEvent.  Should push in with https://github.com/PMDCollab/PMDC/pull/17/files#diff-eeadad3f1a2c26d87e475c7aab122933e5c0af2c68daeeda3176d6ad9753a340