### PR TITLE
All Starters Mod - Budew -> Shinx

### DIFF
--- a/MODS/All_Starters/Data/StartParams.xml
+++ b/MODS/All_Starters/Data/StartParams.xml
@@ -233,7 +233,7 @@
     <Name/>
   </StartChar>
   <StartChar>
-    <Species>budew</Species>
+    <Species>shinx</Species>
     <Form>0</Form>
     <Skin>normal</Skin>
     <Gender>Unknown</Gender>


### PR DESCRIPTION
The original mod upload advertised all present PMD starters, with Shinx's slot set at dex #406, which is Budew instead of Shinx. To match intended behavior, and seeing that budew is not a starter, change budew to shinx.

I have let the original modder know about this change.