### PR TITLE
Implemented in-dungeon recruitment list

### DIFF
--- a/Data/Script/recruit_list.lua
+++ b/Data/Script/recruit_list.lua
@@ -21,10 +21,6 @@ RECRUIT_LIST = {}
 -- -----------------------------------------------
 -- Constants
 -- -----------------------------------------------
-RECRUIT_LIST.recruitMenuOption = "Recruitment search"
-RECRUIT_LIST.menuTitle = "Potential Recruits"
-RECRUIT_LIST.noRecruitsMessage = "No recruits available"
-
 
 RECRUIT_LIST.hide =                    0
 RECRUIT_LIST.undiscovered =            1
@@ -45,11 +41,13 @@ RECRUIT_LIST.colorList = {'#FFFFFF', '#FFFFFF', '#00FFFF', '#FFFF00', '#FFFFA0',
 -- string is replaced with "???" before wrapping
 function RECRUIT_LIST.colorName(monster, mode, asterisk)
     local name = _DATA:GetMonster(monster).Name:ToLocal()
-    if asterisk then name = "*"..name end -- asterisk is for mons that are not in the spawn list but spawned at floor start
-    if mode == 1 then name = '???' end
+    if asterisk then name = "\u{E111}"..name end -- asterisk is for mons that are not in the spawn list but spawned at floor start
+    if mode == RECRUIT_LIST.undiscovered then name = '???' end
     local color = RECRUIT_LIST.colorList[mode]
     return '[color='..color..']'..name..'[color]'
 end
+
+UnrecruitableType = luanet.import_type('PMDC.LevelGen.MobSpawnUnrecruitable')
 
 -- Extracts and sorts the list of all mons that are spawned at the start of the current floor
 -- Non-respawning mons will have an asterisk at the start of their name
@@ -78,14 +76,13 @@ function RECRUIT_LIST.compileInitialFloorList()
             -- check if the mon is recruitable
             local features = spawnList:GetSpawn(j).SpawnFeatures
             for f = 0, features.Count-1, 1 do
-                if RECRUIT_LIST.getClass(features[f]) == "PMDC.LevelGen.MobSpawnUnrecruitable" then
+                if LUA_ENGINE:TypeOf(features[f]) == luanet.ctype(UnrecruitableType) then
                     hide = true -- do not show in recruit list if cannot recruit
                 end
             end
 
             -- add the member and its display mode to the list
             if not hide and list.entries[member] == nil then
-                print("added "..member, false)
                 table.insert(list.keys, member)
                 list.entries[member] = false
             end
@@ -105,7 +102,6 @@ function RECRUIT_LIST.compileInitialFloorList()
 
             -- add the member and its display mode to the list
             if not hide and list.entries[member] == nil then
-                print("added "..member, true)
                 table.insert(list.keys, member)
                 list.entries[member] = true
             end
@@ -121,58 +117,9 @@ function RECRUIT_LIST.compileInitialFloorList()
 end
 
 
--- Extracts a list of all mons currently spawned on the current floor and
--- then appends them at the end of the spawn list, all while pairing them to
--- the display mode that should be used for that mon's name in the menu
--- output: a new list of table entries containing these properties:RECRUIT_LIST
--- {string species, int mode, boolean asterisk}
 function RECRUIT_LIST.compileCurrentList()
-    SV.temp = SV.temp or {}
-    local list = SV.temp.floorList or {
-        keys = {},
-        entries = {}
-    }
-
-    local new_list = {
-        keys = {},
-        entries = {}
-    }
-    -- abort immediately if we're not inside a dungeon
-    if RogueEssence.GameManager.Instance.CurrentScene ~= RogueEssence.Dungeon.DungeonScene.Instance then
-        return new_list
-    end
-
-    local map = _ZONE.CurrentMap
-    local teams = map.MapTeams
-
-    for i = 0, teams.Count-1, 1 do
-        local team = teams[i].Players
-        for j = 0, team.Count-1, 1 do
-            local member = team[j].BaseForm.Species
-            local state = _DATA.Save:GetMonsterUnlock(member)
-            local mode = RECRUIT_LIST.hide -- default is to not show non-respawning mons if unknown
-
-            -- check if the mon has been seen or obtained
-            if state == RogueEssence.Data.GameProgress.UnlockState.Discovered then
-                mode = RECRUIT_LIST.extra_discovered
-            elseif state == RogueEssence.Data.GameProgress.UnlockState.Completed then
-                if _DATA:GetMonster(member).Forms.Count>1 then
-                    mode = RECRUIT_LIST.extra_obtainedMultiForm
-                else
-                    mode = RECRUIT_LIST.extra_obtained
-                end
-            end
-            -- do not show in recruit list if cannot recruit
-            if team[j].Unrecruitable then mode = RECRUIT_LIST.hide end
-
-            -- add the member and its display mode to the list if it's not in any of them already
-            if mode > RECRUIT_LIST.hide and list.entries[member] == nil and new_list.entries[member] == nil then
-                print("found "..member, false)
-                table.insert(new_list.keys, member)
-                new_list.entries[member] = {mode, false}
-            end
-        end
-    end
+    
+    local list = RECRUIT_LIST.compileInitialFloorList()
 
     -- turn first list into final output
     local ret = {}
@@ -184,11 +131,7 @@ function RECRUIT_LIST.compileCurrentList()
         if state == RogueEssence.Data.GameProgress.UnlockState.Discovered then
             mode = RECRUIT_LIST.discovered
         elseif state == RogueEssence.Data.GameProgress.UnlockState.Completed then
-            if _DATA:GetMonster(key).Forms.Count>1 then
-                mode = RECRUIT_LIST.obtainedMultiForm --special color for multi-form mons
-            else
-                mode = RECRUIT_LIST.obtained
-            end
+            mode = RECRUIT_LIST.obtained
         end
 
         local entry = {
@@ -199,27 +142,9 @@ function RECRUIT_LIST.compileCurrentList()
         table.insert(ret,entry)
     end
 
-    -- put new list into final output
-    for _,key in pairs(new_list.keys) do
-        local entry = {
-            species = key,
-            mode = new_list.entries[key][1],
-            asterisk = new_list.entries[key][2]
-        }
-        table.insert(ret,entry)
-    end
     return ret
 end
 
--- Returns the class of an object as string. Useful to extract and check C# classes
-function RECRUIT_LIST.getClass(csobject)
-    if not csobject then return "nil" end
-    local namet = getmetatable(csobject).__name
-    if not namet then return type(csobject) end
-    for a in namet:gmatch('([^,]+)') do
-        return a
-    end
-end
 
 -- Returns the class of an object as string. Useful to extract and check C# classes
 function RECRUIT_LIST.tri(check, y, n)
@@ -254,11 +179,11 @@ function RecruitmentListMenu:DrawMenu()
     --Standard menu divider. Reuse this whenever you need a menu divider at the top for a title.
     self.menu.MenuElements:Add(RogueEssence.Menu.MenuDivider(RogueElements.Loc(8, 8 + 12), self.menu.Bounds.Width - 8 * 2))
 
-    self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RECRUIT_LIST.menuTitle, RogueElements.Loc(16, 8)))
+    self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RogueEssence.StringKey("MENU_RECRUITMENT_TITLE"):ToLocal(), RogueElements.Loc(16, 8)))
 
     -- add a special message if there are no entries
     if #self.list<1 then
-        self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RECRUIT_LIST.noRecruitsMessage, RogueElements.Loc(16, 24)))
+        self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RogueEssence.StringKey("MENU_RECRUITMENT_NONE"):ToLocal(), RogueElements.Loc(16, 24)))
         return
     end
 
@@ -281,11 +206,11 @@ function RecruitmentListMenu:DrawMenu()
         -- positional parameters
         local line = count % self.ENTRY_LINES
         local col = count // self.ENTRY_LINES
-        local xpad = 16
+        local xpad = 24
         local ypad = 24
         local xdist = ((self.menu.Bounds.Width-32)//self.ENTRY_COLUMNS)
         local ydist = 14
-        local xadjust = RECRUIT_LIST.tri(self.list[i].asterisk and self.list[i].mode > RECRUIT_LIST.undiscovered, 6, 0)
+        local xadjust = RECRUIT_LIST.tri(self.list[i].asterisk and self.list[i].mode > RECRUIT_LIST.undiscovered, 10, 0)
 
         -- add element
         local x = xpad + xdist * col - xadjust

--- a/Data/Script/recruit_list.lua
+++ b/Data/Script/recruit_list.lua
@@ -1,0 +1,333 @@
+require 'common'
+
+RECRUIT_LIST = {}
+--[[
+    recruit_list.lua
+    by MistressNebula
+
+    This file contains all functions necessary to generate Recruitment Lists for dungeons, as well as
+    the routine used to show the list itself
+
+    Every time a floor is loaded, the system takes a snapshot of what Pokémon are in the spawn pool
+    and adds to them those that are not in the spawn pool but are spawned regardless on turn 0 (like
+    Ralts in Moonlit Courtyard, for example). Those that are not in the spawn pool will be marked with
+    an asterisk when the Recruitment List is opened.
+
+    When opening the menu, the game will check again for any other recruitable, spawned monster (Monster
+    Houses and other special events) and will show them at the bottom of the list, in cyan if not recruited
+    and in a faded version of the recruit color if they are.
+]]--
+
+-- -----------------------------------------------
+-- Constants
+-- -----------------------------------------------
+RECRUIT_LIST.recruitMenuOption = "Recruitment search"
+RECRUIT_LIST.menuTitle = "Potential Recruits"
+RECRUIT_LIST.noRecruitsMessage = "No recruits available"
+
+
+RECRUIT_LIST.hide =                    0
+RECRUIT_LIST.undiscovered =            1
+RECRUIT_LIST.discovered =              2
+RECRUIT_LIST.extra_discovered =        3
+RECRUIT_LIST.obtained =                4
+RECRUIT_LIST.extra_obtained =          5
+RECRUIT_LIST.obtainedMultiForm =       6
+RECRUIT_LIST.extra_obtainedMultiForm = 7
+
+RECRUIT_LIST.colorList = {'#FFFFFF', '#FFFFFF', '#00FFFF', '#FFFF00', '#FFFFA0', '#FFA500', '#FFE0A0'}
+
+-- -----------------------------------------------
+-- Functions
+-- -----------------------------------------------
+
+-- Wraps a string with a color bracket corresponding to mode. If mode is 1, the
+-- string is replaced with "???" before wrapping
+function RECRUIT_LIST.colorName(monster, mode, asterisk)
+    local name = _DATA:GetMonster(monster).Name:ToLocal()
+    if asterisk then name = "*"..name end -- asterisk is for mons that are not in the spawn list but spawned at floor start
+    if mode == 1 then name = '???' end
+    local color = RECRUIT_LIST.colorList[mode]
+    return '[color='..color..']'..name..'[color]'
+end
+
+-- Extracts and sorts the list of all mons that are spawned at the start of the current floor
+-- Non-respawning mons will have an asterisk at the start of their name
+-- returns a table containing the following properties:
+-- {table{string} keys, table{string -> boolean} entries}
+function RECRUIT_LIST.compileInitialFloorList()
+    local list = {
+        keys = {},
+        entries = {}
+    }
+    -- abort immediately if we're not inside a dungeon
+    if RogueEssence.GameManager.Instance.CurrentScene ~= RogueEssence.Dungeon.DungeonScene.Instance then
+        return list
+    end
+
+    local map = _ZONE.CurrentMap
+    local spawns = map.TeamSpawns
+
+    -- get the spawn list
+    for i = 0, spawns.Count-1, 1 do
+        local spawnList = spawns:GetSpawn(i):GetPossibleSpawns()
+        for j = 0, spawnList.Count-1, 1 do
+            local member = spawnList:GetSpawn(j).BaseForm.Species
+            local hide = false
+
+            -- check if the mon is recruitable
+            local features = spawnList:GetSpawn(j).SpawnFeatures
+            for f = 0, features.Count-1, 1 do
+                if RECRUIT_LIST.getClass(features[f]) == "PMDC.LevelGen.MobSpawnUnrecruitable" then
+                    hide = true -- do not show in recruit list if cannot recruit
+                end
+            end
+
+            -- add the member and its display mode to the list
+            if not hide and list.entries[member] == nil then
+                print("added "..member, false)
+                table.insert(list.keys, member)
+                list.entries[member] = false
+            end
+        end
+    end
+
+    -- get the currently spawned mons
+    local teams = map.MapTeams
+    for i = 0, teams.Count-1, 1 do
+        local team = teams[i].Players
+        for j = 0, team.Count-1, 1 do
+            local member = team[j].BaseForm.Species
+            local hide = false
+
+            -- do not show in recruit list if cannot recruit
+            if team[j].Unrecruitable then hide = true end
+
+            -- add the member and its display mode to the list
+            if not hide and list.entries[member] == nil then
+                print("added "..member, true)
+                table.insert(list.keys, member)
+                list.entries[member] = true
+            end
+        end
+    end
+
+    -- sort spawn list
+    table.sort(list.keys, function (a, b)
+        return _DATA:GetMonster(a).IndexNum < _DATA:GetMonster(b).IndexNum
+    end)
+
+    return list
+end
+
+
+-- Extracts a list of all mons currently spawned on the current floor and
+-- then appends them at the end of the spawn list, all while pairing them to
+-- the display mode that should be used for that mon's name in the menu
+-- output: a new list of table entries containing these properties:RECRUIT_LIST
+-- {string species, int mode, boolean asterisk}
+function RECRUIT_LIST.compileCurrentList()
+    SV.temp = SV.temp or {}
+    local list = SV.temp.floorList or {
+        keys = {},
+        entries = {}
+    }
+
+    local new_list = {
+        keys = {},
+        entries = {}
+    }
+    -- abort immediately if we're not inside a dungeon
+    if RogueEssence.GameManager.Instance.CurrentScene ~= RogueEssence.Dungeon.DungeonScene.Instance then
+        return new_list
+    end
+
+    local map = _ZONE.CurrentMap
+    local teams = map.MapTeams
+
+    for i = 0, teams.Count-1, 1 do
+        local team = teams[i].Players
+        for j = 0, team.Count-1, 1 do
+            local member = team[j].BaseForm.Species
+            local state = _DATA.Save:GetMonsterUnlock(member)
+            local mode = RECRUIT_LIST.hide -- default is to not show non-respawning mons if unknown
+
+            -- check if the mon has been seen or obtained
+            if state == RogueEssence.Data.GameProgress.UnlockState.Discovered then
+                mode = RECRUIT_LIST.extra_discovered
+            elseif state == RogueEssence.Data.GameProgress.UnlockState.Completed then
+                if _DATA:GetMonster(member).Forms.Count>1 then
+                    mode = RECRUIT_LIST.extra_obtainedMultiForm
+                else
+                    mode = RECRUIT_LIST.extra_obtained
+                end
+            end
+            -- do not show in recruit list if cannot recruit
+            if team[j].Unrecruitable then mode = RECRUIT_LIST.hide end
+
+            -- add the member and its display mode to the list if it's not in any of them already
+            if mode > RECRUIT_LIST.hide and list.entries[member] == nil and new_list.entries[member] == nil then
+                print("found "..member, false)
+                table.insert(new_list.keys, member)
+                new_list.entries[member] = {mode, false}
+            end
+        end
+    end
+
+    -- turn first list into final output
+    local ret = {}
+    for _,key in pairs(list.keys) do
+        local state = _DATA.Save:GetMonsterUnlock(key)
+        local mode = RECRUIT_LIST.undiscovered -- default is to "???" list 1 mons if unknown
+
+        -- check if the mon has been seen or obtained
+        if state == RogueEssence.Data.GameProgress.UnlockState.Discovered then
+            mode = RECRUIT_LIST.discovered
+        elseif state == RogueEssence.Data.GameProgress.UnlockState.Completed then
+            if _DATA:GetMonster(key).Forms.Count>1 then
+                mode = RECRUIT_LIST.obtainedMultiForm --special color for multi-form mons
+            else
+                mode = RECRUIT_LIST.obtained
+            end
+        end
+
+        local entry = {
+            species = key,
+            mode = mode,
+            asterisk = list.entries[key]
+        }
+        table.insert(ret,entry)
+    end
+
+    -- put new list into final output
+    for _,key in pairs(new_list.keys) do
+        local entry = {
+            species = key,
+            mode = new_list.entries[key][1],
+            asterisk = new_list.entries[key][2]
+        }
+        table.insert(ret,entry)
+    end
+    return ret
+end
+
+-- Returns the class of an object as string. Useful to extract and check C# classes
+function RECRUIT_LIST.getClass(csobject)
+    if not csobject then return "nil" end
+    local namet = getmetatable(csobject).__name
+    if not namet then return type(csobject) end
+    for a in namet:gmatch('([^,]+)') do
+        return a
+    end
+end
+
+-- Returns the class of an object as string. Useful to extract and check C# classes
+function RECRUIT_LIST.tri(check, y, n)
+    if check then return y else return n end
+end
+
+-- -----------------------------------------------
+-- Recruitment List Menu
+-- -----------------------------------------------
+-- Menu that displays the recruitment list to the player
+RecruitmentListMenu = Class('RecruitmentListMenu')
+
+function RecruitmentListMenu:initialize()
+    assert(self, "RecruitmentListMenu:initialize(): self is nil!")
+
+    self.ENTRY_LINES = 10
+    self.ENTRY_COLUMNS = 2
+    self.ENTRY_LIMIT = self.ENTRY_LINES * self.ENTRY_COLUMNS
+
+    self.menu = RogueEssence.Menu.ScriptableMenu(32, 32, 256, 176, function(input) self:Update(input) end)
+    self.dirPressed = false
+    self.list = {}
+    self.list = RECRUIT_LIST.compileCurrentList()
+    self.page = 0
+    self.PAGE_MAX = (#self.list+1)//self.ENTRY_LIMIT
+
+    self:DrawMenu()
+end
+
+function RecruitmentListMenu:DrawMenu()
+    self.menu.MenuElements:Clear()
+    --Standard menu divider. Reuse this whenever you need a menu divider at the top for a title.
+    self.menu.MenuElements:Add(RogueEssence.Menu.MenuDivider(RogueElements.Loc(8, 8 + 12), self.menu.Bounds.Width - 8 * 2))
+
+    self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RECRUIT_LIST.menuTitle, RogueElements.Loc(16, 8)))
+
+    -- add a special message if there are no entries
+    if #self.list<1 then
+        self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RECRUIT_LIST.noRecruitsMessage, RogueElements.Loc(16, 24)))
+        return
+    end
+
+    --Add page number if it has more than one
+    if self.PAGE_MAX>0 then
+        local pagenum = "("..tostring(self.page+1).."/"..tostring(self.PAGE_MAX+1)..")"
+        self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(pagenum, RogueElements.Loc(self.menu.Bounds.Width - 8, 8),RogueElements.DirH.Right))
+    end
+
+    --how many entries we have populated so far
+    local count = 0
+
+    --other helper indexes
+    local start_pos = self.page * self.ENTRY_LIMIT
+    local end_pos = math.min(start_pos+self.ENTRY_LIMIT, #self.list)
+    start_pos = start_pos + 1
+
+    --populate entries with mon list
+    for i=start_pos, end_pos, 1 do
+        -- positional parameters
+        local line = count % self.ENTRY_LINES
+        local col = count // self.ENTRY_LINES
+        local xpad = 16
+        local ypad = 24
+        local xdist = ((self.menu.Bounds.Width-32)//self.ENTRY_COLUMNS)
+        local ydist = 14
+        local xadjust = RECRUIT_LIST.tri(self.list[i].asterisk and self.list[i].mode > RECRUIT_LIST.undiscovered, 6, 0)
+
+        -- add element
+        local x = xpad + xdist * col - xadjust
+        local y = ypad + ydist * line
+        local text = RECRUIT_LIST.colorName(self.list[i].species, self.list[i].mode, self.list[i].asterisk)
+        self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(text, RogueElements.Loc(x, y)))
+        count = count + 1
+    end
+end
+
+function RecruitmentListMenu:Update(input)
+    if input:JustPressed(RogueEssence.FrameInput.InputType.Cancel) then
+        _GAME:SE("Menu/Cancel")
+        _MENU:RemoveMenu()
+    elseif input:JustPressed(RogueEssence.FrameInput.InputType.Menu) then
+        _GAME:SE("Menu/Cancel")
+        _MENU:RemoveMenu()
+    elseif input.Direction == RogueElements.Dir8.Right then
+        if not self.dirPressed then
+            if self.page >= self.PAGE_MAX then
+                _GAME:SE("Menu/Cancel")
+                self.page = self.PAGE_MAX
+            else
+                self.page = self.page +1
+                _GAME:SE("Menu/Skip")
+                self:DrawMenu()
+            end
+            self.dirPressed = true
+        end
+    elseif input.Direction == RogueElements.Dir8.Left then
+        if not self.dirPressed then
+            if self.page <= 0 then
+                _GAME:SE("Menu/Cancel")
+                self.page = 0
+            else
+                self.page = self.page -1
+                _GAME:SE("Menu/Skip")
+                self:DrawMenu()
+            end
+            self.dirPressed = true
+        end
+    elseif input.Direction == RogueElements.Dir8.None then
+        self.dirPressed = false
+    end
+end

--- a/Data/Script/services/debug_tools/init.lua
+++ b/Data/Script/services/debug_tools/init.lua
@@ -7,9 +7,11 @@
 ]]--
 require 'common'
 require 'services.baseservice'
+require 'recruit_list'
 
 --Declare class DebugTools
 local DebugTools = Class('DebugTools', BaseService)
+
 
 --[[---------------------------------------------------------------
     DebugTools:initialize()
@@ -45,6 +47,35 @@ end
 function DebugTools:OnDeinit()
   assert(self, 'DebugTools:OnDeinit() : self is null!')
   PrintInfo("\n<!> ExampleSvc: Deinit..")
+end
+
+--[[---------------------------------------------------------------
+    DebugTools:OnMenuButtonPressed()
+      When the main menu button is pressed or the main menu should be enabled this is called!
+      This is called as a coroutine.
+---------------------------------------------------------------]]
+function DebugTools:OnMenuButtonPressed()
+  if DebugTools.MainMenu == nil then
+    DebugTools.MainMenu = RogueEssence.Menu.MainMenu()
+  end
+  DebugTools.MainMenu:SetupChoices()
+
+
+  if RogueEssence.GameManager.Instance.CurrentScene == RogueEssence.Dungeon.DungeonScene.Instance then
+    DebugTools.MainMenu.Choices:RemoveAt(5)
+    DebugTools.MainMenu.Choices:Insert(5, RogueEssence.Menu.MenuTextChoice("Others", function () _MENU:AddMenu(DebugTools:OthersMenuWithRecruitScan(), false) end))
+  end
+  DebugTools.MainMenu:SetupTitleAndSummary()
+  DebugTools.MainMenu:InitMenu()
+  TASK:WaitTask(_MENU:ProcessMenuCoroutine(DebugTools.MainMenu))
+end
+
+function DebugTools:OthersMenuWithRecruitScan()
+  local menu = RogueEssence.Menu.OthersMenu()
+  menu:SetupChoices();
+  menu.Choices:Insert(1, RogueEssence.Menu.MenuTextChoice(RECRUIT_LIST.recruitMenuOption, function () _MENU:AddMenu(RecruitmentListMenu:new().menu, false) end))
+  menu:InitMenu();
+  return menu
 end
 
 --[[---------------------------------------------------------------
@@ -103,10 +134,10 @@ function DebugTools:OnNewGame()
     --  GAME:GivePlayerStorageItem(ii)
     --  SV.unlocked_trades[ii] = true
     --end
-  
+
     SV.base_camp.ExpositionComplete = true
     SV.base_camp.IntroComplete = true
-	SV.test_grounds.DemoComplete = true
+    SV.test_grounds.DemoComplete = true
 	SV.General.Starter = _DATA.Save.ActiveTeam.Players[0].BaseForm
   end
 end
@@ -117,16 +148,16 @@ end
 ---------------------------------------------------------------]]
 function DebugTools:OnUpgrade()
   assert(self, 'DebugTools:OnUpgrade() : self is null!')
-  
+
   PrintInfo("=>> Loading version")
   _DATA.Save.NextDest = _DATA.StartMap
-  
-  SV.checkpoint = 
+
+  SV.checkpoint =
   {
     Zone    = 'guildmaster_island', Segment  = -1,
     Map  = 1, Entry  = 0
   }
-  
+
   if SV.test_grounds.DemoComplete == nil then
     SV.test_grounds =
     {
@@ -137,84 +168,84 @@ function DebugTools:OnUpgrade()
       DemoComplete = false,
     }
   end
-  
+
   SV.test_grounds.Starter = { Species="pikachu", Form=0, Skin="normal", Gender=2 }
   SV.test_grounds.Partner = { Species="eevee", Form=0, Skin="normal", Gender=1 }
-  
+
   if SV.missions == nil then
     SV.missions =
-	{
-	  Missions = { },
-	  FinishedMissions = { },
-	}
+    {
+      Missions = { },
+      FinishedMissions = { },
+    }
   end
-  
-  
+
+
   -- end
   if SV.unlocked_trades ~= nil then
   else
     SV.unlocked_trades = {}
   end
-  
+
   if SV.General.Starter == nil then
     SV.General.Starter = MonsterID("bulbasaur", 0, "normal", Gender.Male)
   end
-  
+
   local oldVersion = _DATA.Save.GameVersion
   if oldVersion.Major <= 0 and oldVersion.Minor <= 6 and oldVersion.Build <= 7 then
     _DATA.Save:DeleteOutdatedAssets(RogueEssence.Data.DataManager.DataType.Item)
   end
   if oldVersion.Major <= 0 and oldVersion.Minor <= 7 then
-  
-  SV.base_camp.FerryUnlocked = true
-  SV.base_camp.FerryIntroduced = true
-  
-SV.magnagate =
-{
-  cards = 0,
-  portal = false
-}
 
-SV.shimmer_bay = 
-{
-  TookTreasure  = false
-}
+    SV.base_camp.FerryUnlocked = true
+    SV.base_camp.FerryIntroduced = true
 
-SV.manaphy_egg = 
-{
-  Taken = false,
-  ExpositionComplete = false,
-  Hatched = false
-}
+    SV.magnagate =
+    {
+      cards = 0,
+      portal = false
+    }
 
-SV.roaming_legends =
-{
-  Raikou = false,
-  Entei = false,
-  Suicune = false,
-  Celebi = false,
-  Darkrai = false
-}
+    SV.shimmer_bay =
+    {
+      TookTreasure  = false
+    }
+
+    SV.manaphy_egg =
+    {
+      Taken = false,
+      ExpositionComplete = false,
+      Hatched = false
+    }
+
+    SV.roaming_legends =
+    {
+      Raikou = false,
+      Entei = false,
+      Suicune = false,
+      Celebi = false,
+      Darkrai = false
+    }
 
 
-SV.sleeping_caldera = 
-{
-  TookTreasure  = false,
-  GotHeatran = false
-}
-  
-SV.dex = {
-  CurrentRewardIdx = 1
-}
-	
-SV.moonlit_end = 
-{
-  ExpositionComplete  = false
-}
+    SV.sleeping_caldera =
+    {
+      TookTreasure  = false,
+      GotHeatran = false
+    }
 
-	GAME:UnlockDungeon('fertile_valley')
+    SV.dex = {
+      CurrentRewardIdx = 1
+    }
+
+    SV.moonlit_end =
+    {
+      ExpositionComplete  = false
+    }
+
+    GAME:UnlockDungeon('fertile_valley')
   end
-  
+
   PrintInfo("=>> Loaded version")
 end
 
@@ -250,14 +281,39 @@ function DebugTools:OnLossPenalty(save)
   end
 end
 
+
+--[[---------------------------------------------------------------
+    DebugTools:OnDungeonFloorEnter()
+      Called when entering a new dungeon floor this is called
+  ---------------------------------------------------------------]]
+function DebugTools:OnDungeonFloorEnter(mapid, mapobj)
+  -- TODO fix
+  -- This is the best i could come up with, but it gets messed up by
+  -- script reload in dev menu. I leave fixing this to you, Audino.
+  SV.temp = SV.temp or {}
+  SV.temp.floorList = RECRUIT_LIST.compileInitialFloorList()
+end
+
+--[[---------------------------------------------------------------
+    DebugTools:OnDungeonFloorExit()
+      Called when leaving a dungeon floor this is called.
+  ---------------------------------------------------------------]]
+function DebugTools:OnDungeonFloorExit(mapid, mapobj)
+  SV.temp = SV.temp or {}
+  SV.temp.floorList = nil -- clean list
+end
+
 ---Summary
 -- Subscribe to all channels this service wants callbacks from
 function DebugTools:Subscribe(med)
   med:Subscribe("DebugTools", EngineServiceEvents.Init,                function() self.OnInit(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.Deinit,              function() self.OnDeinit(self) end )
+  med:Subscribe("DebugTools", EngineServiceEvents.MenuButtonPressed,        function() self.OnMenuButtonPressed() end )
   med:Subscribe("DebugTools", EngineServiceEvents.NewGame,        function() self.OnNewGame(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.UpgradeSave,        function() self.OnUpgrade(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.LossPenalty,        function(_, args) self.OnLossPenalty(self, args[0]) end )
+  med:Subscribe("DebugTools", EngineServiceEvents.DungeonFloorEnter,        function(_, args) self.OnDungeonFloorEnter(self,args[0],args[1]) end)
+  med:Subscribe("DebugTools", EngineServiceEvents.DungeonFloorExit,        function(_, args) self.OnDungeonFloorExit(self,args[0],args[1]) end)
 --  med:Subscribe("DebugTools", EngineServiceEvents.GraphicsUnload,      function() self.OnGraphicsUnload(self) end )
 --  med:Subscribe("DebugTools", EngineServiceEvents.Restart,             function() self.OnRestart(self) end )
 end

--- a/Data/Script/services/debug_tools/init.lua
+++ b/Data/Script/services/debug_tools/init.lua
@@ -55,15 +55,13 @@ end
       This is called as a coroutine.
 ---------------------------------------------------------------]]
 function DebugTools:OnMenuButtonPressed()
+  -- TODO: Remove this when the memory leak is fixed or confirmed not a leak
   if DebugTools.MainMenu == nil then
     DebugTools.MainMenu = RogueEssence.Menu.MainMenu()
   end
   DebugTools.MainMenu:SetupChoices()
-
-
   if RogueEssence.GameManager.Instance.CurrentScene == RogueEssence.Dungeon.DungeonScene.Instance then
-    DebugTools.MainMenu.Choices:RemoveAt(5)
-    DebugTools.MainMenu.Choices:Insert(5, RogueEssence.Menu.MenuTextChoice("Others", function () _MENU:AddMenu(DebugTools:OthersMenuWithRecruitScan(), false) end))
+    DebugTools.MainMenu.Choices[5] = RogueEssence.Menu.MenuTextChoice(STRINGS:FormatKey("MENU_OTHERS_TITLE"), function () _MENU:AddMenu(DebugTools:OthersMenuWithRecruitScan(), false) end)
   end
   DebugTools.MainMenu:SetupTitleAndSummary()
   DebugTools.MainMenu:InitMenu()
@@ -71,11 +69,16 @@ function DebugTools:OnMenuButtonPressed()
 end
 
 function DebugTools:OthersMenuWithRecruitScan()
-  local menu = RogueEssence.Menu.OthersMenu()
-  menu:SetupChoices();
-  menu.Choices:Insert(1, RogueEssence.Menu.MenuTextChoice(RECRUIT_LIST.recruitMenuOption, function () _MENU:AddMenu(RecruitmentListMenu:new().menu, false) end))
-  menu:InitMenu();
-  return menu
+  -- TODO: Remove this when the memory leak is fixed or confirmed not a leak
+  if DebugTools.OthersMenu == nil then
+    DebugTools.OthersMenu = RogueEssence.Menu.OthersMenu()
+  end
+  DebugTools.OthersMenu:SetupChoices();
+  if RogueEssence.GameManager.Instance.CurrentScene == RogueEssence.Dungeon.DungeonScene.Instance then
+    DebugTools.OthersMenu.Choices:Insert(1, RogueEssence.Menu.MenuTextChoice(RogueEssence.StringKey("MENU_RECRUITMENT"):ToLocal(), function () _MENU:AddMenu(RecruitmentListMenu:new().menu, false) end))
+  end
+  DebugTools.OthersMenu:InitMenu();
+  return DebugTools.OthersMenu
 end
 
 --[[---------------------------------------------------------------
@@ -85,8 +88,8 @@ end
 function DebugTools:OnNewGame()
   assert(self, 'DebugTools:OnNewGame() : self is null!')
   
-  for ii = 1, _DATA.StartChars.Count, 1 do
-    _DATA.Save:RogueUnlockMonster(_DATA.StartChars[ii-1].Item1.Species)
+  for ii = 1, _DATA.Start.Chars.Count, 1 do
+    _DATA.Save:RogueUnlockMonster(_DATA.Start.Chars[ii-1].ID.Species)
   end
   
   if _DATA.Save.ActiveTeam.Players.Count > 0 then
@@ -134,120 +137,23 @@ function DebugTools:OnNewGame()
     --  GAME:GivePlayerStorageItem(ii)
     --  SV.unlocked_trades[ii] = true
     --end
-
-    SV.base_camp.ExpositionComplete = true
-    SV.base_camp.IntroComplete = true
-    SV.test_grounds.DemoComplete = true
+	
+    --for ii = 1, 10000, 1 do
+    --  mon_id = RogueEssence.Dungeon.MonsterID("bulbasaur", 0, "normal", Gender.Male)
+    --  _DATA.Save.ActiveTeam.Assembly:Add(_DATA.Save.ActiveTeam:CreatePlayer(_DATA.Save.Rand, mon_id, 50, "", 0))
+    --end
+    
+	if SV.base_camp ~= nil then
+      SV.base_camp.ExpositionComplete = true
+      SV.base_camp.IntroComplete = true
+	end
+	if SV.test_grounds ~= nil then
+	  SV.test_grounds.DemoComplete = true
+	end
 	SV.General.Starter = _DATA.Save.ActiveTeam.Players[0].BaseForm
   end
 end
 
---[[---------------------------------------------------------------
-    DebugTools:OnUpgrade()
-      When a save file in an old version is loaded this is called!
----------------------------------------------------------------]]
-function DebugTools:OnUpgrade()
-  assert(self, 'DebugTools:OnUpgrade() : self is null!')
-
-  PrintInfo("=>> Loading version")
-  _DATA.Save.NextDest = _DATA.StartMap
-
-  SV.checkpoint =
-  {
-    Zone    = 'guildmaster_island', Segment  = -1,
-    Map  = 1, Entry  = 0
-  }
-
-  if SV.test_grounds.DemoComplete == nil then
-    SV.test_grounds =
-    {
-      SpokeToPooch = false,
-      AcceptedPooch = false,
-      Starter = { Species="pikachu", Form=0, Skin="normal", Gender=2 },
-      Partner = { Species="eevee", Form=0, Skin="normal", Gender=1 },
-      DemoComplete = false,
-    }
-  end
-
-  SV.test_grounds.Starter = { Species="pikachu", Form=0, Skin="normal", Gender=2 }
-  SV.test_grounds.Partner = { Species="eevee", Form=0, Skin="normal", Gender=1 }
-
-  if SV.missions == nil then
-    SV.missions =
-    {
-      Missions = { },
-      FinishedMissions = { },
-    }
-  end
-
-
-  -- end
-  if SV.unlocked_trades ~= nil then
-  else
-    SV.unlocked_trades = {}
-  end
-
-  if SV.General.Starter == nil then
-    SV.General.Starter = MonsterID("bulbasaur", 0, "normal", Gender.Male)
-  end
-
-  local oldVersion = _DATA.Save.GameVersion
-  if oldVersion.Major <= 0 and oldVersion.Minor <= 6 and oldVersion.Build <= 7 then
-    _DATA.Save:DeleteOutdatedAssets(RogueEssence.Data.DataManager.DataType.Item)
-  end
-  if oldVersion.Major <= 0 and oldVersion.Minor <= 7 then
-
-    SV.base_camp.FerryUnlocked = true
-    SV.base_camp.FerryIntroduced = true
-
-    SV.magnagate =
-    {
-      cards = 0,
-      portal = false
-    }
-
-    SV.shimmer_bay =
-    {
-      TookTreasure  = false
-    }
-
-    SV.manaphy_egg =
-    {
-      Taken = false,
-      ExpositionComplete = false,
-      Hatched = false
-    }
-
-    SV.roaming_legends =
-    {
-      Raikou = false,
-      Entei = false,
-      Suicune = false,
-      Celebi = false,
-      Darkrai = false
-    }
-
-
-    SV.sleeping_caldera =
-    {
-      TookTreasure  = false,
-      GotHeatran = false
-    }
-
-    SV.dex = {
-      CurrentRewardIdx = 1
-    }
-
-    SV.moonlit_end =
-    {
-      ExpositionComplete  = false
-    }
-
-    GAME:UnlockDungeon('fertile_valley')
-  end
-
-  PrintInfo("=>> Loaded version")
-end
 
 --[[---------------------------------------------------------------
     DebugTools:OnLossPenalty()
@@ -264,43 +170,21 @@ function DebugTools:OnLossPenalty(save)
   for i = inv_count, 0, -1 do
     local entry = _DATA:GetItem(save.ActiveTeam:GetInv(i).ID)
     if not entry.CannotDrop then
-      save.ActiveTeam:RemoveFromInv(i);
+      save.ActiveTeam:RemoveFromInv(i)
     end
   end
   
   --remove equips
-  local player_count = GAME:GetPlayerPartyCount()
+  local player_count = save.ActiveTeam.Players.Count
   for i = 0, player_count - 1, 1 do 
-    local player = GAME:GetPlayerPartyMember(i)
+    local player = save.ActiveTeam.Players[i]
     if player.EquippedItem.ID ~= '' and player.EquippedItem.ID ~= nil then 
-      local entry = _DATA:GetItem(player.EquippedItem.ID);
+      local entry = _DATA:GetItem(player.EquippedItem.ID)
       if not entry.CannotDrop then
-         player:SilentDequipItem();
+         player:SilentDequipItem()
       end
     end
   end
-end
-
-
---[[---------------------------------------------------------------
-    DebugTools:OnDungeonFloorEnter()
-      Called when entering a new dungeon floor this is called
-  ---------------------------------------------------------------]]
-function DebugTools:OnDungeonFloorEnter(mapid, mapobj)
-  -- TODO fix
-  -- This is the best i could come up with, but it gets messed up by
-  -- script reload in dev menu. I leave fixing this to you, Audino.
-  SV.temp = SV.temp or {}
-  SV.temp.floorList = RECRUIT_LIST.compileInitialFloorList()
-end
-
---[[---------------------------------------------------------------
-    DebugTools:OnDungeonFloorExit()
-      Called when leaving a dungeon floor this is called.
-  ---------------------------------------------------------------]]
-function DebugTools:OnDungeonFloorExit(mapid, mapobj)
-  SV.temp = SV.temp or {}
-  SV.temp.floorList = nil -- clean list
 end
 
 ---Summary
@@ -310,10 +194,7 @@ function DebugTools:Subscribe(med)
   med:Subscribe("DebugTools", EngineServiceEvents.Deinit,              function() self.OnDeinit(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.MenuButtonPressed,        function() self.OnMenuButtonPressed() end )
   med:Subscribe("DebugTools", EngineServiceEvents.NewGame,        function() self.OnNewGame(self) end )
-  med:Subscribe("DebugTools", EngineServiceEvents.UpgradeSave,        function() self.OnUpgrade(self) end )
   med:Subscribe("DebugTools", EngineServiceEvents.LossPenalty,        function(_, args) self.OnLossPenalty(self, args[0]) end )
-  med:Subscribe("DebugTools", EngineServiceEvents.DungeonFloorEnter,        function(_, args) self.OnDungeonFloorEnter(self,args[0],args[1]) end)
-  med:Subscribe("DebugTools", EngineServiceEvents.DungeonFloorExit,        function(_, args) self.OnDungeonFloorExit(self,args[0],args[1]) end)
 --  med:Subscribe("DebugTools", EngineServiceEvents.GraphicsUnload,      function() self.OnGraphicsUnload(self) end )
 --  med:Subscribe("DebugTools", EngineServiceEvents.Restart,             function() self.OnRestart(self) end )
 end

--- a/Strings/stringsEx.resx
+++ b/Strings/stringsEx.resx
@@ -129,6 +129,9 @@
   <data name="DLG_ASK_STORAGE" xml:space="preserve">
     <value>What will you take out?</value>
     <comment></comment>  </data>
+  <data name="DLG_BAG_SIZE" xml:space="preserve">
+    <value>You can now carry {0} items in your Treasure Bag!</value>
+    <comment></comment>  </data>
   <data name="DLG_CANT_FORGET_SKILL" xml:space="preserve">
     <value>{0} can't forget any more moves.</value>
     <comment></comment>  </data>
@@ -137,6 +140,9 @@
     <comment></comment>  </data>
   <data name="DLG_CANT_RECALL_SKILL" xml:space="preserve">
     <value>{0} has no moves to relearn.</value>
+    <comment></comment>  </data>
+  <data name="DLG_DUNGEON_DEAD_END" xml:space="preserve">
+    <value>This is appears to be the end of the dungeon.[br]It's impossible to go any farther.[pause=0] It's time to go back.</value>
     <comment></comment>  </data>
   <data name="DLG_DUNGEON_UNLOCK" xml:space="preserve">
     <value>A new dungeon has been discovered!</value>
@@ -171,21 +177,6 @@
   <data name="DLG_EVO_NONE_NOW" xml:space="preserve">
     <value>...[pause=0]{0} cannot evolve right now.</value>
     <comment></comment>  </data>
-  <data name="MSG_PASSAGE_FAIRY" xml:space="preserve">
-    <value>...[pause=0]A mysterious energy permeates the area.</value>
-    <comment></comment>  </data>
-  <data name="MSG_PASSAGE_FAIRY_OPEN" xml:space="preserve">
-    <value>It swirls and gathers around {0}!</value>
-    <comment></comment>  </data>
-  <data name="TITLE_ENRAGED_CALDERA" xml:space="preserve">
-    <value>Enraged Caldera\nB{0}F</value>
-    <comment></comment>  </data>
-  <data name="MSG_PASSAGE_FLYING" xml:space="preserve">
-    <value>...[pause=0]A mysterious wind current is blowing upwards.</value>
-    <comment></comment>  </data>
-  <data name="MSG_PASSAGE_FLYING_OPEN" xml:space="preserve">
-    <value>{0} is carried by the updraft!</value>
-    <comment></comment>  </data>
   <data name="DLG_FORGET_INTRINSIC" xml:space="preserve">
     <value>{0} lost the ability {1}.</value>
     <comment></comment>  </data>
@@ -198,14 +189,41 @@
   <data name="DLG_LOCK" xml:space="preserve">
     <value>It needs a {0} to unlock...</value>
     <comment></comment>  </data>
-  <data name="DLG_LOCK_KEY" xml:space="preserve">
-    <value>Will you unlock it with the {0}?</value>
-    <comment></comment>  </data>
   <data name="DLG_LOCK_GUILD" xml:space="preserve">
     <value>It's sealed with the Guildmaster's emblem...</value>
     <comment></comment>  </data>
   <data name="DLG_LOCK_GUILD_OPEN" xml:space="preserve">
     <value>The seal is reacting to {0}'s badge!</value>
+    <comment></comment>  </data>
+  <data name="DLG_LOCK_KEY" xml:space="preserve">
+    <value>Will you unlock it with the {0}?</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_DESTINATION" xml:space="preserve">
+    <value>You've reached a destination floor!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_ESCORT_DONE" xml:space="preserve">
+    <value>Yes! You completed {0}'s escort mission. {0} is delighted!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_OUTLAW" xml:space="preserve">
+    <value>Wanted outlaw spotted!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_OUTLAW_DONE" xml:space="preserve">
+    <value>Yes!\nKnocked out the outlaw {0}!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_OUTLAW_TRAP" xml:space="preserve">
+    <value>You've fallen into my trap!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_REMINDER" xml:space="preserve">
+    <value>Report back to {0} after leaving the dungeon.</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_RESCUE_ASK" xml:space="preserve">
+    <value>Yes! You've found {0}![scroll]Do you want to use your badge to rescue {0}?</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_RESCUE_DONE" xml:space="preserve">
+    <value>Your badge shines on {0}, and {0} is transported away magically!</value>
+    <comment></comment>  </data>
+  <data name="DLG_MISSION_RESCUE_THANKS" xml:space="preserve">
+    <value>Thank you! I'll see you outside with a reward when you return!</value>
     <comment></comment>  </data>
   <data name="DLG_RECEIVE_ITEM" xml:space="preserve">
     <value>{0} received the {1}!</value>
@@ -241,10 +259,10 @@
     <value>land {0} critical hits in battle</value>
     <comment></comment>  </data>
   <data name="EVO_REQ_HUNGER_HIGH" xml:space="preserve">
-    <value>be full</value>
+    <value>with overfilled belly</value>
     <comment></comment>  </data>
   <data name="EVO_REQ_HUNGER_LOW" xml:space="preserve">
-    <value>be hungry</value>
+    <value>with empty belly</value>
     <comment></comment>  </data>
   <data name="EVO_REQ_ITEM" xml:space="preserve">
     <value>hold {0}</value>
@@ -261,6 +279,9 @@
   <data name="EVO_REQ_SKILL_ELEMENT" xml:space="preserve">
     <value>learn a {0}-type move</value>
     <comment>Evolution requirement: must learn a move of a certain type</comment>  </data>
+  <data name="EVO_REQ_SKILL_USE" xml:space="preserve">
+    <value>used {0} {1} times in a row</value>
+    <comment></comment>  </data>
   <data name="EVO_REQ_STAT_BOOST" xml:space="preserve">
     <value>raise {0} in battle</value>
     <comment></comment>  </data>
@@ -273,11 +294,47 @@
   <data name="EVO_REQ_TRADE" xml:space="preserve">
     <value>must be from another team</value>
     <comment>Evolution requirement: must be from another team</comment>  </data>
+  <data name="ITEM_KEY_CARD_GRASS" xml:space="preserve">
+    <value>Grass Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_MIST" xml:space="preserve">
+    <value>Mist Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_MOON" xml:space="preserve">
+    <value>Moon Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_SAND" xml:space="preserve">
+    <value>Sand Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_STAR" xml:space="preserve">
+    <value>Star Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_SUN" xml:space="preserve">
+    <value>Sun Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_WATER" xml:space="preserve">
+    <value>Water Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_WIND" xml:space="preserve">
+    <value>Wind Card</value>
+    <comment></comment>  </data>
+  <data name="ITEM_KEY_CARD_WORLD" xml:space="preserve">
+    <value>World Card</value>
+    <comment></comment>  </data>
   <data name="MENU_FORGET_SKILL" xml:space="preserve">
     <value>Forget Move</value>
     <comment></comment>  </data>
   <data name="MENU_RECALL_SKILL" xml:space="preserve">
     <value>Recall Move</value>
+    <comment></comment>  </data>
+  <data name="MENU_RECRUITMENT_TITLE" xml:space="preserve">
+    <value>Potential Recruits</value>
+    <comment></comment>  </data>
+  <data name="MENU_RECRUITMENT" xml:space="preserve">
+    <value>Recruitment Search</value>
+    <comment></comment>  </data>
+  <data name="MENU_RECRUITMENT_NONE" xml:space="preserve">
+    <value>No recruits available</value>
     <comment></comment>  </data>
   <data name="MSG_ABSORB" xml:space="preserve">
     <value>{0} absorbed the attack with {1}!</value>
@@ -513,6 +570,12 @@
   <data name="MSG_CLOUD_NINE" xml:space="preserve">
     <value>{0}'s Cloud Nine made the weather disappear!</value>
     <comment></comment>  </data>
+  <data name="MSG_CLOUDY_END" xml:space="preserve">
+    <value>The clouds disappeared.</value>
+    <comment></comment>  </data>
+  <data name="MSG_CLOUDY_START" xml:space="preserve">
+    <value>The sky is cloudy...</value>
+    <comment></comment>  </data>
   <data name="MSG_CONFUSE_ALREADY" xml:space="preserve">
     <value>{0} is already confused!</value>
     <comment></comment>  </data>
@@ -592,7 +655,7 @@
     <value>{0} became a decoy to attract attacks!</value>
     <comment></comment>  </data>
   <data name="MSG_DESTINY_BOND" xml:space="preserve">
-    <value></value>
+    <value>{0} is trying to take {1} with it!</value>
     <comment></comment>  </data>
   <data name="MSG_DESTINY_BOND_END" xml:space="preserve">
     <value>{0} gave up the Destiny Bond!</value>
@@ -631,6 +694,9 @@
     <value>{0} resurfaced!</value>
     <comment></comment>  </data>
   <data name="MSG_DMG_BOOST_ANY_STATUS" xml:space="preserve">
+    <value>The power was boosted due to the its major status!</value>
+    <comment></comment>  </data>
+  <data name="MSG_DMG_BOOST_ANY_STATUS_OTHER" xml:space="preserve">
     <value>The power was boosted due to the target's major status!</value>
     <comment></comment>  </data>
   <data name="MSG_DMG_BOOST_LOW_HP" xml:space="preserve">
@@ -744,6 +810,9 @@
   <data name="MSG_EXTRA_TURN" xml:space="preserve">
     <value>{0}'s {1} let it move again!</value>
     <comment></comment>  </data>
+  <data name="MSG_FAKE_ITEM" xml:space="preserve">
+    <value>The {0} was actually [a/an] {1}!</value>
+    <comment></comment>  </data>
   <data name="MSG_FIRE_SPIN_START" xml:space="preserve">
     <value>{0} was trapped in a vortex of fire!</value>
     <comment></comment>  </data>
@@ -777,9 +846,6 @@
   <data name="MSG_FLY_END" xml:space="preserve">
     <value>{0} dropped back down!</value>
     <comment></comment>  </data>
-  <data name="MSG_SKY_DROP_CHARGE" xml:space="preserve">
-    <value>{0} took {1} into the sky!</value>
-    <comment></comment>  </data>
   <data name="MSG_FOCUS_ENERGY_START" xml:space="preserve">
     <value>{0} is getting pumped!</value>
     <comment></comment>  </data>
@@ -794,12 +860,6 @@
     <comment></comment>  </data>
   <data name="MSG_FOG_START" xml:space="preserve">
     <value>The fog is deep...</value>
-    <comment></comment>  </data>
-  <data name="MSG_CLOUDY_END" xml:space="preserve">
-    <value>The clouds disappeared.</value>
-    <comment></comment>  </data>
-  <data name="MSG_CLOUDY_START" xml:space="preserve">
-    <value>The sky is cloudy...</value>
     <comment></comment>  </data>
   <data name="MSG_FOLLOW_ME_ALREADY" xml:space="preserve">
     <value>{0} is already the center of attention!</value>
@@ -845,9 +905,6 @@
     <comment></comment>  </data>
   <data name="MSG_GIVE_ITEM_AWAY" xml:space="preserve">
     <value>{0} gave away the {1}!</value>
-    <comment></comment>  </data>
-  <data name="MSG_FAKE_ITEM" xml:space="preserve">
-    <value>The {0} was actually a {1}!</value>
     <comment></comment>  </data>
   <data name="MSG_GRASSY_TERRAIN_END" xml:space="preserve">
     <value>The grass disappeared from the battlefield.</value>
@@ -1062,20 +1119,14 @@
   <data name="MSG_LOCK_OPEN_FLOOR" xml:space="preserve">
     <value>Doors were opened throughout the floor!</value>
     <comment>English translation is intentionally using phrases that are unofficial, so feel free to use your own spin on things for translation.</comment>  </data>
-  <data name="MSG_SWITCH_NEEDED_ONE" xml:space="preserve">
-    <value>{0} more switch remains.</value>
-    <comment></comment>  </data>
-  <data name="MSG_SWITCH_NEEDED_MULTI" xml:space="preserve">
-    <value>{0} more switches remain.</value>
-    <comment></comment>  </data>
-  <data name="MSG_SWITCH_NEEDED_SYNC" xml:space="preserve">
-    <value>Team members must be on all {0} switches.</value>
-    <comment></comment>  </data>
   <data name="MSG_LOSE_HELD_ITEM" xml:space="preserve">
     <value>{0}'s {1} was lost!</value>
     <comment></comment>  </data>
   <data name="MSG_LOSE_ITEM" xml:space="preserve">
     <value>The {1} in {0}'s bag was lost!</value>
+    <comment></comment>  </data>
+  <data name="MSG_LOST_GUEST" xml:space="preserve">
+    <value>{0} was left behind...</value>
     <comment></comment>  </data>
   <data name="MSG_LOVE" xml:space="preserve">
     <value>{0} is attracted and can't target {1}!</value>
@@ -1227,6 +1278,12 @@
   <data name="MSG_MUG" xml:space="preserve">
     <value>All held items were drawn to {0}!</value>
     <comment></comment>  </data>
+  <data name="MSG_MYSTERIOSITY_END" xml:space="preserve">
+    <value>The distortion disappeared!</value>
+    <comment></comment>  </data>
+  <data name="MSG_MYSTERIOSITY_START" xml:space="preserve">
+    <value>A mysterious distortion appears in the dungeon!</value>
+    <comment></comment>  </data>
   <data name="MSG_NIGHTMARE" xml:space="preserve">
     <value>{0} is having nightmares!</value>
     <comment></comment>  </data>
@@ -1286,6 +1343,21 @@
     <comment></comment>  </data>
   <data name="MSG_PASS_ATTACK" xml:space="preserve">
     <value>{0} passed the attack to {1}!</value>
+    <comment></comment>  </data>
+  <data name="MSG_PASSAGE_FAIRY" xml:space="preserve">
+    <value>...[pause=0]A mysterious energy permeates the area.</value>
+    <comment></comment>  </data>
+  <data name="MSG_PASSAGE_FAIRY_OPEN" xml:space="preserve">
+    <value>It swirls and gathers around {0}!</value>
+    <comment></comment>  </data>
+  <data name="MSG_PASSAGE_FLYING" xml:space="preserve">
+    <value>...[pause=0]A mysterious wind current is blowing upwards.</value>
+    <comment></comment>  </data>
+  <data name="MSG_PASSAGE_FLYING_OPEN" xml:space="preserve">
+    <value>{0} is carried by the updraft!</value>
+    <comment></comment>  </data>
+  <data name="MSG_PASTEL_VEIL" xml:space="preserve">
+    <value>{0} can't be poisoned due to Pastel Veil!</value>
     <comment></comment>  </data>
   <data name="MSG_PAUSE" xml:space="preserve">
     <value>{0} is paused and can't move!</value>
@@ -1380,6 +1452,12 @@
   <data name="MSG_PROTECT_WITH" xml:space="preserve">
     <value>{0} is protected by {1}!</value>
     <comment></comment>  </data>
+  <data name="MSG_PSYCHIC_TERRAIN_END" xml:space="preserve">
+    <value>The weirdness disappeared from the battlefield.</value>
+    <comment></comment>  </data>
+  <data name="MSG_PSYCHIC_TERRAIN_START" xml:space="preserve">
+    <value>The battlefield got weird!</value>
+    <comment></comment>  </data>
   <data name="MSG_QUICK_GUARD_START" xml:space="preserve">
     <value>{0} is protected from long-range attacks!</value>
     <comment></comment>  </data>
@@ -1423,13 +1501,16 @@
     <value>{0} joined the party to go on adventures!</value>
     <comment>The version for when the player doesn't have a team name.</comment>  </data>
   <data name="MSG_RECRUIT_BOOST_START" xml:space="preserve">
-    <value>{0}'s chances of recruitment was boosted!</value>
+    <value>{0}'s chance of recruitment was boosted!</value>
     <comment></comment>  </data>
   <data name="MSG_RECRUIT_FAIL" xml:space="preserve">
     <value>{0} seems hesitant to join the team...</value>
     <comment></comment>  </data>
+  <data name="MSG_RECRUIT_GUEST" xml:space="preserve">
+    <value>{0} was brought along for the adventure.</value>
+    <comment></comment>  </data>
   <data name="MSG_RECYCLE" xml:space="preserve">
-    <value>{0}'s {1} was recycled and became a {2}</value>
+    <value>{0}'s {1} was recycled and became a {2}.</value>
     <comment></comment>  </data>
   <data name="MSG_REDIRECT_ATTACK" xml:space="preserve">
     <value>{0} redirected the attack!</value>
@@ -1551,6 +1632,9 @@
   <data name="MSG_SKY_ATTACK_CHARGE" xml:space="preserve">
     <value>{0} became cloaked in a harsh light!</value>
     <comment></comment>  </data>
+  <data name="MSG_SKY_DROP_CHARGE" xml:space="preserve">
+    <value>{0} took {1} into the sky!</value>
+    <comment></comment>  </data>
   <data name="MSG_SLEEP_ALREADY" xml:space="preserve">
     <value>{0} is already asleep!</value>
     <comment></comment>  </data>
@@ -1650,6 +1734,9 @@
   <data name="MSG_STAT_DROP_PROTECT" xml:space="preserve">
     <value>{0}'s {1} prevented its {2} from dropping!</value>
     <comment></comment>  </data>
+  <data name="MSG_STAT_DROP_REFLECT" xml:space="preserve">
+    <value>{0}'s {1} reflected the stat change!</value>
+    <comment></comment>  </data>
   <data name="MSG_STAT_DROP_TRIGGER" xml:space="preserve">
     <value>The stat drop triggered {0}'s {1}!</value>
     <comment></comment>  </data>
@@ -1661,6 +1748,9 @@
     <comment></comment>  </data>
   <data name="MSG_STAT_SWAP" xml:space="preserve">
     <value>{0} swapped its {1} with its {2}!</value>
+    <comment></comment>  </data>
+  <data name="MSG_STAT_SWAP_OTHER" xml:space="preserve">
+    <value>{0} swapped its {1} with {2}!</value>
     <comment></comment>  </data>
   <data name="MSG_STATIC" xml:space="preserve">
     <value>{0}'s Static paralyzes on contact!</value>
@@ -1752,6 +1842,15 @@
   <data name="MSG_SWEET_VEIL_DROWSY" xml:space="preserve">
     <value>{0} can't become drowsy due to Sweet Veil!</value>
     <comment></comment>  </data>
+  <data name="MSG_SWITCH_NEEDED_MULTI" xml:space="preserve">
+    <value>{0} more switches remain.</value>
+    <comment></comment>  </data>
+  <data name="MSG_SWITCH_NEEDED_ONE" xml:space="preserve">
+    <value>{0} more switch remains.</value>
+    <comment></comment>  </data>
+  <data name="MSG_SWITCH_NEEDED_SYNC" xml:space="preserve">
+    <value>Team members must be on all {0} switches.</value>
+    <comment></comment>  </data>
   <data name="MSG_SYNCHRO_FAIL" xml:space="preserve">
     <value>{0} isn't the same type as {1}!</value>
     <comment></comment>  </data>
@@ -1778,12 +1877,6 @@
     <comment></comment>  </data>
   <data name="MSG_TIME_UP" xml:space="preserve">
     <value>It's right nearby! It's gusting hard!</value>
-    <comment></comment>  </data>
-  <data name="MSG_MYSTERIOSITY_START" xml:space="preserve">
-    <value>A mysterious distortion appears in the dungeon!</value>
-    <comment></comment>  </data>
-  <data name="MSG_MYSTERIOSITY_END" xml:space="preserve">
-    <value>The distortion disappeared!</value>
     <comment></comment>  </data>
   <data name="MSG_TIME_WARNING_1" xml:space="preserve">
     <value>Something's stirring...</value>
@@ -2043,6 +2136,9 @@
   <data name="TALK_ADVICE_NEUTRAL" xml:space="preserve">
     <value>Be careful around wild Pokémon when you're in these Mystery Dungeons.[br]But me?[pause=0] I'm harmless.[br]You can tell from the color of my map icon,[pause=0] and the yellow outline around my shadow!</value>
     <comment></comment>  </data>
+  <data name="TALK_ADVICE_POISON" xml:space="preserve">
+    <value>If you get poisoned, don't panic![scroll]If you wait it out without moving or attacking, and you'll take less damage.</value>
+    <comment></comment>  </data>
   <data name="TALK_ADVICE_RANGE" xml:space="preserve">
     <value>I'd be careful around those Ledyba...[br]Their Supersonic hits at a long range,[pause=0] and can travel through multiple team members!</value>
     <comment></comment>  </data>
@@ -2053,7 +2149,7 @@
     <value>Whew, that did the trick![pause=0] Why don't you take this?</value>
     <comment></comment>  </data>
   <data name="TALK_ADVICE_STAT_DROP" xml:space="preserve">
-    <value>Aurgh, that Aipom threw some sand in my eyes and now my attacks are harder to hit![br]I need to get to a Wonder Tile...</value>
+    <value>Aurgh, that Aipom threw some sand in my eyes and now I can barely hit anything![br]I need to get to a Wonder Tile...</value>
     <comment></comment>  </data>
   <data name="TALK_ADVICE_SWITCH_GAMEPAD" xml:space="preserve">
     <value>If you want another Pokémon to take the lead, use {0} or {1} to switch leaders!</value>
@@ -2066,6 +2162,33 @@
     <comment></comment>  </data>
   <data name="TALK_CANT" xml:space="preserve">
     <value>[myname] can't talk just now.</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_ASK" xml:space="preserve">
+    <value>Take the lost Pokémon along?</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_ACCEPT" xml:space="preserve">
+    <value>Can... can you get me out of here?</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_FULL_001" xml:space="preserve">
+    <value>[tmp]This can't be real...</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_FULL_002" xml:space="preserve">
+    <value>[tmp]This feels so strange...</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_FULL_003" xml:space="preserve">
+    <value>[tmp]H-Hey... what are you?</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_FULL_004" xml:space="preserve">
+    <value>[tmp]... ...</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_HALF" xml:space="preserve">
+    <value>[tmp]Owie! Why is everyone so mean!?</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_PINCH" xml:space="preserve">
+    <value>[tmp]I can't go on...</value>
+    <comment></comment>  </data>
+  <data name="TALK_ESCORT_SISTER_START" xml:space="preserve">
+    <value>[tmp]Where am I?  Am I dreaming?  I feel a slight breeze...</value>
     <comment></comment>  </data>
   <data name="TALK_FULL_0000" xml:space="preserve">
     <value>Let's do our best!</value>
@@ -2943,6 +3066,24 @@
   <data name="TALK_HALF_0200" xml:space="preserve">
     <value>It's gotten even tougher now.</value>
     <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_001" xml:space="preserve">
+    <value>[tmp]Hey it's me, manager. I'm okay after all!</value>
+    <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_002" xml:space="preserve">
+    <value>[tmp]Don't worry, I'll be right back on the mountain, kekeke...</value>
+    <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_003" xml:space="preserve">
+    <value>[tmp]I said you should go now.  There's nothing here for you.</value>
+    <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_004" xml:space="preserve">
+    <value>[tmp]fufufu... so you're not fooled after all.</value>
+    <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_005" xml:space="preserve">
+    <value>[tmp]Fine, we'll do this the hard way!</value>
+    <comment></comment>  </data>
+  <data name="TALK_OUTLAW_DISGUISE_ATTACKED" xml:space="preserve">
+    <value>[tmp]What? How!?</value>
+    <comment></comment>  </data>
   <data name="TALK_PINCH_0000" xml:space="preserve">
     <value>I'm going down for the count...</value>
     <comment></comment>  </data>
@@ -3620,5 +3761,8 @@
     <comment></comment>  </data>
   <data name="TALK_WAIT_0190" xml:space="preserve">
     <value>Good to see you!</value>
+    <comment></comment>  </data>
+  <data name="TITLE_ENRAGED_CALDERA" xml:space="preserve">
+    <value>Enraged Caldera\nB{0}F</value>
     <comment></comment>  </data>
 </root>


### PR DESCRIPTION
Added the "Recruitment search" option in the Others menu in dungeons and implemented a rudimental "on floor enter" way to determine what Pokémon are spawned in the floor. Consider it a way to differentiate between those mons that spawn only at the start of a floor from stuff like Monster House spawns and other events. The only problem is, the generated list is subsceptible to disruption if scripts are reloaded and i fear i cannot do anything about it from lua, so i leave fixing that issue to you.