### PR TITLE
Added new lua menus + small recruit list optimization

### DIFF
--- a/Data/Script/ground/base_camp_2/init.lua
+++ b/Data/Script/ground/base_camp_2/init.lua
@@ -1,6 +1,8 @@
 require 'common'
+require 'menu.InventorySelectMenu'
 require 'menu.SkillSelectMenu'
 require 'menu.SkillTutorMenu'
+require 'menu.TeamSelectMenu'
 
 local base_camp_2 = {}
 local MapStrings = {}
@@ -1609,7 +1611,7 @@ function base_camp_2.Bug_Complete()
 end
 
 base_camp_2.boost_tbl = { }
---{ Level = 0, EXP = 100, HP = 0, Atk = 0, Def = 0, SpAtk = 0, SpDef = 0, Speed = 0, NegateExp = false, NegateStat = false }
+--{ Level = 0, EXP = 100, HP = 0, Atk = 0, Def = 0, SpAtk = 0, SpDef = 0, Speed = 0, NegateExp = false, NegateStat = false, GummiEffect = nil}
 base_camp_2.boost_tbl["food_apple"] = { EXP = 100 }
 base_camp_2.boost_tbl["food_apple_big"] = { EXP = 300 }
 base_camp_2.boost_tbl["food_apple_huge"] = { EXP = 1000 }
@@ -1630,6 +1632,25 @@ base_camp_2.boost_tbl["berry_apicot"] = { SpDef = 2 }
 base_camp_2.boost_tbl["berry_salac"] = { Speed = 2 }
 base_camp_2.boost_tbl["berry_enigma"] = { HP = 1 }
 base_camp_2.boost_tbl["berry_micle"] = { Atk = 1, SpAtk = 1 }
+base_camp_2.boost_tbl["gummi_black"] = { GummiEffect = 'dark' }
+base_camp_2.boost_tbl["gummi_blue"] = { GummiEffect = 'water' }
+base_camp_2.boost_tbl["gummi_brown"] = { GummiEffect = 'ground' }
+base_camp_2.boost_tbl["gummi_clear"] = { GummiEffect = 'ice' }
+base_camp_2.boost_tbl["gummi_gold"] = { GummiEffect = 'psychic' }
+base_camp_2.boost_tbl["gummi_grass"] = { GummiEffect = 'grass' }
+base_camp_2.boost_tbl["gummi_gray"] = { GummiEffect = 'rock' }
+base_camp_2.boost_tbl["gummi_green"] = { GummiEffect = 'bug' }
+base_camp_2.boost_tbl["gummi_magenta"] = { GummiEffect = 'fairy' }
+base_camp_2.boost_tbl["gummi_orange"] = { GummiEffect = 'fighting' }
+base_camp_2.boost_tbl["gummi_pink"] = { GummiEffect = 'poison' }
+base_camp_2.boost_tbl["gummi_purple"] = { GummiEffect = 'ghost' }
+base_camp_2.boost_tbl["gummi_red"] = { GummiEffect = 'fire' }
+base_camp_2.boost_tbl["gummi_royal"] = { GummiEffect = 'dragon' }
+base_camp_2.boost_tbl["gummi_silver"] = { GummiEffect = 'steel' }
+base_camp_2.boost_tbl["gummi_sky"] = { GummiEffect = 'flying' }
+base_camp_2.boost_tbl["gummi_white"] = { GummiEffect = 'normal' }
+base_camp_2.boost_tbl["gummi_yellow"] = { GummiEffect = 'electric' }
+base_camp_2.boost_tbl["gummi_wonder"] = { HP = 1, Atk = 1, Def = 1, SpAtk = 1, SpDef = 1, Speed = 1 }
 base_camp_2.boost_tbl["boost_nectar"] = { HP = 1, Atk = 1, Def = 1, SpAtk = 1, SpDef = 1, Speed = 1 }
 base_camp_2.boost_tbl["boost_hp_up"] = { HP = 4 }
 base_camp_2.boost_tbl["boost_protein"] = { Atk = 4 }
@@ -1656,10 +1677,9 @@ function base_camp_2.Drink_Order_Flow()
   while state > -1 do
   
     if state == 0 then
-	  --pass in base_camp_2.boost_tbl as the table of eligible items
-	  UI:SellMenu()
-	  UI:WaitForChoice()
-	  local result = UI:ChoiceResult()
+      --passing in base_camp_2.boost_tbl as the table of eligible items
+      local filter = function(slot) return not not base_camp_2.boost_tbl[slot.ID] end
+      local result = InventorySelectMenu.run(STRINGS:FormatKey("MENU_ITEM_TITLE"), filter)
 			
 	  if #result > 0 then
 		cart = result
@@ -1669,11 +1689,9 @@ function base_camp_2.Drink_Order_Flow()
 	  end
     elseif state == 1 then
       UI:WaitShowDialogue(STRINGS:Format(MapStrings['Juice_Order_Who']))
-      UI:TutorTeamMenu(base_camp_2.Tutor_Can_Forget)
-      UI:WaitForChoice()
-      local result = UI:ChoiceResult()
+      local member = TeamSelectMenu.runPartyMenu()
 	  
-      if result > -1 then
+      if member then
 	  
 		for ii = #cart, 1, -1 do
 			if cart[ii].IsEquipped then
@@ -1683,8 +1701,7 @@ function base_camp_2.Drink_Order_Flow()
 			end
 		end
 		cart = {}
-	  
-	    member = GAME:GetPlayerPartyMember(result)
+
         UI:WaitShowDialogue(STRINGS:Format(MapStrings['Juice_Order_Begin']))
 		SOUND:PlayBattleSE("DUN_Drink")
         UI:WaitShowDialogue(STRINGS:Format(MapStrings['Juice_Order_Drink'], member:GetDisplayName(true)))

--- a/Data/Script/menu/InventorySelectMenu.lua
+++ b/Data/Script/menu/InventorySelectMenu.lua
@@ -1,0 +1,166 @@
+--[[
+    InventorySelectMenu
+    lua port by MistressNebula
+
+    Opens a menu, potentially with multiple pages, that allows the player to select an item
+    in their inventory.
+    It contains a run method for quick instantiation.
+    This equivalent is NOT SAFE FOR REPLAYS. Do NOT use in dungeons until further notice.
+]]
+
+
+--- Menu for selecting a skill from a specific list of items.
+InventorySelectMenu = Class("InventorySelectMenu")
+
+--- Creates a new ``InventorySelectMenu`` instance using the provided list and callbacks.
+--- @param title string the title this window will have.
+--- @param filter function a function that takes ``RogueEssence.Dungeon.InvSlot`` object and returns a boolean. Any slot that does not pass this check will have its option disabled in the menu. Defaults to ``return true``.
+--- @param confirm_action function the function called when the selection is confirmed. It will have a table array of ``RogueEssence.Dungeon.InvSlot`` objects passed to it as a parameter.
+--- @param refuse_action function the function called when the player presses the cancel or menu button.
+--- @param menu_width number the width of this window. Default is 176.
+function InventorySelectMenu:initialize(title, filter, confirm_action, refuse_action, menu_width, includeEquips)
+    if includeEquips == nil then includeEquips = true end
+
+    -- constants
+    self.MAX_ELEMENTS = 8
+
+    -- parsing data
+    self.confirmAction = confirm_action
+    self.refuseAction = refuse_action
+    self.menuWidth = menu_width or 176
+    self.filter = filter or function(_) return true end
+    self.includeEquips = includeEquips
+    self.slotList = self:load_slots()
+    self.optionsList = self:generate_options()
+    self.max_choices = self:count_valid()
+
+    self.multiConfirmAction = function(list)
+        _MENU:RemoveMenu()
+        self.confirmAction(self:multiConfirm(list))
+    end
+
+    self.choices = {} -- result
+
+    -- creating the menu
+    local origin = RogueElements.Loc(16,16)
+    local option_array = luanet.make_array(RogueEssence.Menu.MenuElementChoice, self.optionsList)
+    self.menu = RogueEssence.Menu.ScriptableMultiPageMenu(origin, self.menuWidth, title, option_array, 0, self.MAX_ELEMENTS, refuse_action, refuse_action, false, self.max_choices, self.multiConfirmAction)
+    self.menu.ChoiceChangedFunction = function() self:updateSummary() end
+    --self.menu.ChoiceToggledFunction = function() self:updateSummary() end TODO drink effect preview window update function at some point somewhere, probably in a subclass
+
+    -- create the summary window
+    local GraphicsManager = RogueEssence.Content.GraphicsManager
+
+    self.summary = RogueEssence.Menu.ItemSummary(RogueElements.Rect.FromPoints(
+            RogueElements.Loc(16, GraphicsManager.ScreenHeight - 8 - GraphicsManager.MenuBG.TileHeight * 2 - 14 * 4), --LINE_HEIGHT = 12, VERT_SPACE = 14
+            RogueElements.Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)))
+    self.menu.SummaryMenus:Add(self.summary)
+    --TODO drink effect preview window at some point somewhere, probably in a subclass
+    self:updateSummary()
+end
+
+--- Loads the item slots that will be part of the menu.
+--- @return table a standardized version of the item list
+function InventorySelectMenu:load_slots()
+    local list = {}
+
+    if self.includeEquips then
+        -- add equipped items
+        local chars = _DATA.Save.ActiveTeam.Players
+        for i=0, chars.Count-1, 1 do
+            local char = chars[i]
+            if char.EquippedItem.ID and char.EquippedItem.ID ~= "" then
+                local entry = RogueEssence.Dungeon.InvSlot(true, i)
+                table.insert(list, entry)
+            end
+        end
+    end
+    -- add rest of inventory
+    for i=0, _DATA.Save.ActiveTeam:GetInvCount()-1, 1 do
+        local entry = RogueEssence.Dungeon.InvSlot(false, i)
+        table.insert(list, entry)
+    end
+    return list
+end
+
+--- Processes the menu's properties and generates the ``RogueEssence.Menu.MenuElementChoice`` list that will be displayed.
+--- @return table a list of ``RogueEssence.Menu.MenuElementChoice`` objects.
+function InventorySelectMenu:generate_options()
+    local options = {}
+    for i=1, #self.slotList, 1 do
+        local slot = self.slotList[i]
+        local item, equip_id = nil, nil
+        if slot.IsEquipped then
+            equip_id = slot.Slot
+            item = _DATA.Save.ActiveTeam.Players[equip_id].EquippedItem
+        else
+            item = _DATA.Save.ActiveTeam:GetInv(slot.Slot)
+        end
+        local enabled = self.filter(item)
+        local color = Color.White
+        if not enabled then color = Color.Red end
+
+        local name = item:GetDisplayName()
+        if equip_id then name = tostring(equip_id+1)..": "..name end
+        local text_name = RogueEssence.Menu.MenuText(name, RogueElements.Loc(2, 1), color)
+        local option = RogueEssence.Menu.MenuElementChoice(function() self:choose(i) end, enabled, text_name)
+        table.insert(options, option)
+    end
+    return options
+end
+
+--- Counts the number of valid options generated.
+--- @return number the number of valid options.
+function InventorySelectMenu:count_valid()
+    local count = 0
+    for _, option in pairs(self.optionsList) do
+        if option.Enabled then count = count+1 end
+    end
+    return count
+end
+
+--- Closes the menu and calls the menu's confirmation callback.
+--- The result must be retrieved by accessing the choice variable of this object, which will hold
+--- the chosen index as the single element of a table array.
+--- @param index number the index of the chosen character, wrapped inside of a single element table array.
+function InventorySelectMenu:choose(index)
+    self.choices = {index-1}
+    self.multiConfirmAction(self.choices)
+end
+
+--- Updates the summary window.
+function InventorySelectMenu:updateSummary()
+    self.summary:SetItem(_DATA.Save.ActiveTeam:GetInv(self.slotList[self.menu.CurrentChoiceTotal+1].Slot))
+end
+
+--- Extract the list of selected slots.
+--- @param list table a table array containing the menu indexes of the chosen items.
+--- @return table a table array containing ``RogueEssence.Dungeon.InvSlot`` objects.
+function InventorySelectMenu:multiConfirm(list)
+    local result = {}
+    for _, index in pairs(list) do
+        local inv_slot = self.slotList[index+1]
+        PrintInfo(tostring(inv_slot.IsEquipped).."\t"..tostring(inv_slot.Slot))
+        table.insert(result, inv_slot)
+    end
+    return result
+end
+
+
+
+
+--- Creates a basic ``InventorySelectMenu`` instance using the provided parameters, then runs it and returns its output.
+--- @param title string the title this window will have
+--- @param filter function a function that takes a ``RogueEssence.Dungeon.InvSlot`` object and returns a boolean. Any ``InvSlot`` that does not pass this check will have its option disabled in the menu. Defaults to ``return true``.
+--- @param includeEquips boolean if true, the party's equipped items will be included in the menu. defaults to true.
+--- @return userdata a table array containing the chosen ``RogueEssence.Dungeon.InvSlot`` objects.
+function InventorySelectMenu.run(title, filter, includeEquips)
+
+    local ret = {}
+    local choose = function(list) ret = list end
+    local refuse = function() _MENU:RemoveMenu() end
+    local menu = InventorySelectMenu:new(title, filter, choose, refuse, includeEquips)
+    UI:SetCustomMenu(menu.menu)
+    UI:WaitForChoice()
+    return ret
+end

--- a/Data/Script/menu/TeamSelectMenu.lua
+++ b/Data/Script/menu/TeamSelectMenu.lua
@@ -1,0 +1,140 @@
+--[[
+    TeamSelectMenu
+    lua port by MistressNebula
+
+    Opens a menu, potentially with multiple pages, that allows the player to select a Pokémon.
+    It contains a run method for quick instantiation, as well as a way to open
+    a version of itself containing the current party members.
+    This equivalent is NOT SAFE FOR REPLAYS. Do NOT use in dungeons until further notice.
+]]
+
+
+--- Menu for selecting a skill from a specific list of ``RogueEssence.Dungeon.Character`` objects.
+TeamSelectMenu = Class("TeamSelectMenu")
+
+--- Creates a new ``TeamSelectMenu`` instance using the provided list and callbacks.
+--- This function throws an error if the parameter ``char_list`` contains less than 1 entries.
+--- @param title string the title this window will have.
+--- @param char_list table an array, list or lua array table containing ``RogueEssence.Dungeon.Character`` objects.
+--- @param filter function a function that takes a ``RogueEssence.Dungeon.Character`` object and returns a boolean. Any character that does not pass this check will have its option disabled in the menu. Defaults to ``return true``.
+--- @param confirm_action function the function called when a slot is chosen. It will have a ``RogueEssence.Dungeon.Character`` passed to it as a parameter.
+--- @param refuse_action function the function called when the player presses the cancel or menu button.
+--- @param menu_width number the width of this window. Default is 160.
+function TeamSelectMenu:initialize(title, char_list, filter, confirm_action, refuse_action, menu_width)
+    -- param validity check
+    local len = 0
+    if type(char_list) == 'table' then len = #char_list
+    else len = char_list.Count end
+    if len <1 then
+        --abort if skill list is empty
+        error("parameter 'char_list' cannot be an empty collection")
+    end
+
+    -- constants
+    self.MAX_ELEMENTS = 5
+
+    -- parsing data
+    self.confirmAction = confirm_action
+    self.refuseAction = refuse_action
+    self.menuWidth = menu_width or 160
+    self.filter = filter or function(_) return true end
+    self.charList = self:load_chars(char_list)
+    self.optionsList = self:generate_options()
+    if #self.optionsList<self.MAX_ELEMENTS then self.MAX_ELEMENTS = #self.optionsList end
+
+    self.choice = nil -- result
+
+    -- creating the menu
+    local origin = RogueElements.Loc(16,16)
+    local option_array = luanet.make_array(RogueEssence.Menu.MenuElementChoice, self.optionsList)
+    self.menu = RogueEssence.Menu.ScriptableMultiPageMenu(origin, self.menuWidth, title, option_array, 0, self.MAX_ELEMENTS, refuse_action, refuse_action, false)
+    self.menu.ChoiceChangedFunction = function() self:updateSummary() end
+
+    -- creating the summary window
+    local GraphicsManager = RogueEssence.Content.GraphicsManager
+
+    self.summary = RogueEssence.Menu.TeamMiniSummary(RogueElements.Rect.FromPoints(RogueElements.Loc(16,
+            GraphicsManager.ScreenHeight - 8 - GraphicsManager.MenuBG.TileHeight * 2 - 14 * 5), --LINE_HEIGHT = 12, VERT_SPACE = 14
+            RogueElements.Loc(GraphicsManager.ScreenWidth - 16, GraphicsManager.ScreenHeight - 8)))
+    self.menu.SummaryMenus:Add(self.summary)
+    self:updateSummary()
+end
+
+
+--- Loads the characters that will be part of the menu.
+--- @param char_list table an array, list or lua array table containing ``RogueEssence.Dungeon.Character`` objects.
+--- @return table a standardized version of the character list
+function TeamSelectMenu:load_chars(char_list)
+    local list = {}
+
+    if type(char_list) == 'table' then
+        for _, char in pairs(char_list) do table.insert(list, char) end
+    else
+        for char in luanet.each(LUA_ENGINE:MakeList(char_list)) do table.insert(list, char) end
+    end
+    return list
+end
+
+--- Processes the menu's properties and generates the ``RogueEssence.Menu.MenuElementChoice`` list that will be displayed.
+--- @return table a list of ``RogueEssence.Menu.MenuElementChoice`` objects.
+function TeamSelectMenu:generate_options()
+    local options = {}
+    for i=1, #self.charList, 1 do
+        local char = self.charList[i]
+        local enabled = self.filter(char)
+        local color = Color.White
+        if not enabled then color = Color.Red end
+
+        local name = char:GetDisplayName(true)
+        local level = char.Level
+        local text_name = RogueEssence.Menu.MenuText(name, RogueElements.Loc(2, 1), color)
+        local text_lv_label = RogueEssence.Menu.MenuText(STRINGS:FormatKey("MENU_TEAM_LEVEL_SHORT"), RogueElements.Loc(self.menuWidth - 8 * 7 + 6, 1), RogueElements.DirV.Up, RogueElements.DirH.Right, color)
+        local text_level = RogueEssence.Menu.MenuText(tostring(level), RogueElements.Loc(self.menuWidth - 8 * 4, 1), RogueElements.DirV.Up, RogueElements.DirH.Right, color)
+        local option = RogueEssence.Menu.MenuElementChoice(function() self:choose(i) end, enabled, text_name, text_lv_label, text_level)
+        table.insert(options, option)
+    end
+    return options
+end
+
+--- Closes the menu and calls the menu's confirmation callback.
+--- The result must be retrieved by accessing the choice variable of this object, which will hold
+--- the string id of the chosen skill.
+--- @param index number the index of the chosen character.
+function TeamSelectMenu:choose(index)
+    self.choice = self.charList[index]
+    _MENU:RemoveMenu()
+    self.confirmAction(self.choice)
+end
+
+--- Updates the summary window.
+function TeamSelectMenu:updateSummary()
+    self.summary:SetMember(self.charList[self.menu.CurrentChoiceTotal+1])
+end
+
+
+
+
+--- Creates a basic ``TeamSelectMenu`` instance using the provided list and callbacks, then runs it and returns its output.
+--- @param title string the title this window will have
+--- @param char_list table an array, list or lua array table containing ``RogueEssence.Dungeon.Character`` objects.
+--- @param filter function a function that takes a ``RogueEssence.Dungeon.Character`` object and returns a boolean. Any character that does not pass this check will have its option disabled in the menu. Defaults to ``return true``.
+--- @return userdata the selected character if one was chosen in the menu; ``nil`` otherwise.
+function TeamSelectMenu.run(title, char_list, filter)
+
+    local ret = nil
+    local choose = function(char) ret = char end
+    local refuse = function() _MENU:RemoveMenu() end
+    local menu = TeamSelectMenu:new(title, char_list, filter, choose, refuse)
+    UI:SetCustomMenu(menu.menu)
+    UI:WaitForChoice()
+    return ret
+end
+
+--- Creates a ``TeamSelectMenu`` instance that allows a choice between the current party members.
+--- @param filter function a function that takes a ``RogueEssence.Dungeon.Character`` object and returns a boolean. Any character that does not pass this check will have its option disabled in the menu. Defaults to ``return true``.
+--- @return userdata the selected character if one was chosen in the menu; ``nil`` otherwise.
+function TeamSelectMenu.runPartyMenu(filter)
+    local char_list = _DATA.Save.ActiveTeam.Players
+
+    return TeamSelectMenu.run(STRINGS:FormatKey("MENU_TEAM_TITLE"), char_list, filter)
+end

--- a/Data/Script/recruit_list.lua
+++ b/Data/Script/recruit_list.lua
@@ -118,6 +118,7 @@ end
 
 
 function RECRUIT_LIST.compileCurrentList()
+    if _DATA.Save.NoRecruiting then return {} end
     
     local list = RECRUIT_LIST.compileInitialFloorList()
 
@@ -177,7 +178,6 @@ function RecruitmentListMenu:initialize()
 
     self.menu = RogueEssence.Menu.ScriptableMenu(32, 32, 256, 176, function(input) self:Update(input) end)
     self.dirPressed = false
-    self.list = {}
     self.list = RECRUIT_LIST.compileCurrentList()
     self.page = 0
     self.PAGE_MAX = math.max((#self.list-1)//self.ENTRY_LIMIT+1, 0)
@@ -193,7 +193,7 @@ function RecruitmentListMenu:DrawMenu()
     self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RogueEssence.StringKey("MENU_RECRUITMENT_TITLE"):ToLocal(), RogueElements.Loc(16, 8)))
 
     -- add a special message if there are no entries or recruiting is disabled altogether
-    if #self.list<1 or _DATA.Save.NoRecruiting then
+    if #self.list<1 then
         self.menu.MenuElements:Add(RogueEssence.Menu.MenuText(RogueEssence.StringKey("MENU_RECRUITMENT_NONE"):ToLocal(), RogueElements.Loc(16, 24)))
         return
     end


### PR DESCRIPTION
- Moved NoRecruiting check so that the floor's spawn list is not needlessly filled if recruiting is inactive
- Added TeamSelectMenu.lua and InventorySelectMenu.lua and integrated them in the Juice Stand logic
- Added gummies to base_camp_2.boost_tbl