### PR TITLE
Removed ActiveTeam hardcode from various menus.

### DIFF
--- a/Data/Script/origin/menu/team/AssemblySelectMenu.lua
+++ b/Data/Script/origin/menu/team/AssemblySelectMenu.lua
@@ -330,7 +330,7 @@ function AssemblySelectSubMenu:openSummary()
         is_assembly = true
         index = index_list[choice - team_tail_id]
     end
-    _MENU:AddMenu(RogueEssence.Menu.MemberFeaturesMenu(index, is_assembly, _DATA.Save.ActiveTeam.Assembly.Count > 0), false)
+    _MENU:AddMenu(RogueEssence.Menu.MemberFeaturesMenu(_DATA.Save.ActiveTeam, index, is_assembly, _DATA.Save.ActiveTeam.Assembly.Count > 0, false), false)
 end
 
 

--- a/Data/Script/origin/menu/team/TeamSelectMenu.lua
+++ b/Data/Script/origin/menu/team/TeamSelectMenu.lua
@@ -240,7 +240,7 @@ end
 
 --- Opens the ``RogueEssence.Menu.MemberFeaturesMenu`` of the character selected in the parent menu.
 function TeamSelectSubMenu:openSummary()
-    _MENU:AddMenu(RogueEssence.Menu.MemberFeaturesMenu(self.parent.menu.CurrentChoiceTotal, false, false), false)
+    _MENU:AddMenu(RogueEssence.Menu.MemberFeaturesMenu(_DATA.Save.ActiveTeam, self.parent.menu.CurrentChoiceTotal, false, false, false), false)
 end
 
 


### PR DESCRIPTION
Requires [https://github.com/RogueCollab/RogueEssence/pull/135](https://github.com/RogueCollab/RogueEssence/pull/135) to function properly. 