### PR TITLE
Junction Patch Support

### DIFF
--- a/Data/Script/origin/common.lua
+++ b/Data/Script/origin/common.lua
@@ -1498,10 +1498,10 @@ function COMMON.DoJuncPatch(obj, activator, other_new_dungeons, other_new_ground
 		-- If not, just copy grounds_to_add
 		local groEnts = {}
 		if other_new_grounds then
-			copy(other_new_grounds)
+			groEnts = copy(other_new_grounds)
 			merge(groEnts,grounds_to_add)
 		else
-			dunEnts = copy(grounds_to_add)
+			groEnts = copy(grounds_to_add)
 		end
 		
 		base_script_func(obj, activator, dunEnts, groEnts)

--- a/Data/Script/origin/ground/base_camp/init.lua
+++ b/Data/Script/origin/ground/base_camp/init.lua
@@ -4,8 +4,6 @@ local base_camp = {}
 --------------------------------------------------
 -- Variables
 --------------------------------------------------
-local helper = {}
-
 local CAMP_DUN_ENTRANCES = { 'tropical_path', 'faultline_ridge', 'guildmaster_trail' }
 local CAMP_GRO_ENTRANCES = {
   {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=0},
@@ -378,48 +376,14 @@ function base_camp.RewardDialogue()
 end
 
 --------------------------------------------------
--- Helpers
---------------------------------------------------
--- these should probably be stuffed in some common location!
-function helper.HelperDeepClone(target)
-  local clone = {}
-  if target then
-    for i=1,#target do
-      clone[#clone+1] = target[i]
-    end
-  end
-  return clone
-end
-
-function helper.HelperMerge(tableAddedTo, tableTakenFrom)
-  if tableAddedTo and tableTakenFrom then
-    for i=1,#tableTakenFrom do
-      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
-    end
-  end
-end
-
---------------------------------------------------
 -- Objects Callbacks
 --------------------------------------------------
 
 -- go take in any patched new dungeons and grouns and add them too!
 function base_camp.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-
-  -- do a deep clone to avoid shennaigans
-  -- improvement: cacheing of some sort, probs
-  local dungeon_entrances = helper.HelperDeepClone(CAMP_DUN_ENTRANCES)
-  -- merge these together
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  -- todo
-  -- table.sort(dungeon_entrance,somefuncforcolorsorting)
-
--- same for ground
-  local ground_entrances = helper.HelperDeepClone(CAMP_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, CAMP_DUN_ENTRANCES, CAMP_GRO_ENTRANCES)
 end
 
 function base_camp.First_North_Exit_Touch(obj, activator)  
@@ -459,28 +423,11 @@ function base_camp.Ferry_Action(obj, activator, newDunEnts, newGroEnts)
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_001']))
   SV.base_camp.FerryIntroduced = true
   end
-
- -- do a deep clone to avoid shennaigans
-  -- improvement: cacheing of some sort, probs
-  local dungeon_entrances = helper.HelperDeepClone(FERRY_DUN_ENTRANCES)
-  -- merge these together
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  -- todo
-  -- table.sort(dungeon_entrance,somefuncforcolorsorting)
-
--- same for ground
-  local ground_entrances = helper.HelperDeepClone(FERRY_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  -- work for entrances
-  local dungeon_entrances = FERRY_DUN_ENTRANCES
-  local ground_entrances = FERRY_GRO_ENTRANCES 
   
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_002']))
   
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances, true,
-  ferry,
-  STRINGS:Format(STRINGS.MapStrings['Ferry_Line_003']))
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, FERRY_DUN_ENTRANCE, FERRY_GRO_ENTRANCES, true, ferry, STRINGS:Format(STRINGS.MapStrings['Ferry_Line_003']))
+  
 end
 
 base_camp.sign_count = 0

--- a/Data/Script/origin/ground/base_camp/init.lua
+++ b/Data/Script/origin/ground/base_camp/init.lua
@@ -426,7 +426,7 @@ function base_camp.Ferry_Action(obj, activator, newDunEnts, newGroEnts)
   
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_002']))
   
-  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, FERRY_DUN_ENTRANCE, FERRY_GRO_ENTRANCES, true, ferry, STRINGS:Format(STRINGS.MapStrings['Ferry_Line_003']))
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, FERRY_DUN_ENTRANCES, FERRY_GRO_ENTRANCES, true, ferry, STRINGS:Format(STRINGS.MapStrings['Ferry_Line_003']))
   
 end
 

--- a/Data/Script/origin/ground/base_camp/init.lua
+++ b/Data/Script/origin/ground/base_camp/init.lua
@@ -1,6 +1,23 @@
 require 'origin.common'
 
 local base_camp = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
+
+local CAMP_DUN_ENTRANCES = { 'tropical_path', 'faultline_ridge', 'guildmaster_trail' }
+local CAMP_GRO_ENTRANCES = {
+  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=0},
+  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=0},
+  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
+  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
+  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+local FERRY_DUN_ENTRANCES = { 'lava_floe_island', 'castaway_cave', 'eon_island', 'uncharted_waters', 'inscribed_cave', 'prism_isles' }
+local FERRY_GRO_ENTRANCES = {}
 
 --------------------------------------------------
 -- Map Callbacks
@@ -44,15 +61,15 @@ function base_camp.Enter(map)
     base_camp.RewardDialogue()
     SV.guildmaster_trail.Rewarded = true
     SV.base_camp.ExpositionComplete = true
-  elseif not SV.base_camp.ExpositionComplete then	
+  elseif not SV.base_camp.ExpositionComplete then 
     base_camp.SetupNpcs()
     base_camp.BeginExposition()
     SV.base_camp.ExpositionComplete = true
   else
     base_camp.SetupNpcs()
-	
+  
     base_camp.CheckMissions()
-	
+  
     GAME:FadeIn(20)
   end
   
@@ -86,21 +103,21 @@ function base_camp.SetupNpcs()
   --Noctowl: 64, 252
   --Luxio: 104, 252
   if not SV.family.Sister and SV.family.SisterActiveDays >= 3 then
-	local noctowl = CH('Noctowl')
-	local entrance = CH('NPC_Entrance')
-	GROUND:TeleportTo(noctowl, 64, 252, Direction.Right)
-	GROUND:TeleportTo(entrance, 104, 252, Direction.Left)
+  local noctowl = CH('Noctowl')
+  local entrance = CH('NPC_Entrance')
+  GROUND:TeleportTo(noctowl, 64, 252, Direction.Right)
+  GROUND:TeleportTo(entrance, 104, 252, Direction.Left)
   end
   
   --Wingull: 344, 264
   if not SV.family.Mother and SV.family.MotherActiveDays >= 3 then
-	local coast = CH('NPC_Coast')
-	GROUND:TeleportTo(coast, 232, 456, Direction.Down)
+  local coast = CH('NPC_Coast')
+  GROUND:TeleportTo(coast, 232, 456, Direction.Down)
   end
   
   if SV.team_catch.Status == 1 then
     GROUND:Unhide("NPC_Catch_1")
-	GROUND:Unhide("NPC_Catch_2")
+  GROUND:Unhide("NPC_Catch_2")
   elseif SV.team_catch.Status == 4 then
     -- TODO cycling
   end
@@ -113,11 +130,11 @@ function base_camp.SetupNpcs()
   
   if SV.team_steel.DaysSinceArgue >= 2 and not SV.team_steel.Rescued then
     GROUND:Unhide("NPC_Steel_1")
-	local questname = "QuestSteel"
+  local questname = "QuestSteel"
     local quest = SV.missions.Missions[questname]
-	if quest ~= nil and quest.Complete == COMMON.MISSION_COMPLETE then
-	  GROUND:Unhide("NPC_Steel_2")
-	end
+  if quest ~= nil and quest.Complete == COMMON.MISSION_COMPLETE then
+    GROUND:Unhide("NPC_Steel_2")
+  end
   end
   
   if SV.guildmaster_summit.GameComplete then
@@ -126,10 +143,10 @@ function base_camp.SetupNpcs()
   end
   
   if not SV.family.Sister and SV.family.SisterActiveDays >= 3 then
-	local noctowl = CH('Noctowl')
-	local entrance = CH('NPC_Entrance')
-	GROUND:CharTurnToChar(noctowl,entrance)
-	GROUND:CharTurnToChar(entrance,noctowl)
+  local noctowl = CH('Noctowl')
+  local entrance = CH('NPC_Entrance')
+  GROUND:CharTurnToChar(noctowl,entrance)
+  GROUND:CharTurnToChar(entrance,noctowl)
   end
 end
 
@@ -140,8 +157,8 @@ function base_camp.CheckMissions()
   local quest = SV.missions.Missions["EscortMother"]
   if quest ~= nil then
     if quest.Complete == COMMON.MISSION_COMPLETE then
-	
-      --spawn her	  
+  
+      --spawn her   
       
       GAME:FadeIn(20)
       UI:WaitShowDialogue("Escort mission state: Complete.")
@@ -150,78 +167,78 @@ function base_camp.CheckMissions()
       UI:WaitShowDialogue("The mother drops something as she runs off.")
       
       SV.magnagate.Cards = SV.magnagate.Cards + 1
-	  SV.family.Mother = true
+    SV.family.Mother = true
       COMMON.GiftKeyItem(player, RogueEssence.StringKey("ITEM_KEY_CARD_WATER"):ToLocal())
-	  COMMON.CompleteMission("EscortMother")
-	  
+    COMMON.CompleteMission("EscortMother")
+    
     end
   end
 end
 
 function base_camp.BeginExposition()  
 
-	-- move founder to team if not in party
-	-- get party
-	local party_table = GAME:GetPlayerPartyTable()
-	-- check for presence
-	local in_party = false
-	for ii = 1, #party_table, 1 do
-	  local ent = party_table[ii]
-	  if ent.IsFounder then
-	    in_party = true
-		break
-	  end
-	end
-	
-	-- if no, search assembly and then add to party
-	if not in_party then
-	  local assemblyCount = GAME:GetPlayerAssemblyCount()
+  -- move founder to team if not in party
+  -- get party
+  local party_table = GAME:GetPlayerPartyTable()
+  -- check for presence
+  local in_party = false
+  for ii = 1, #party_table, 1 do
+    local ent = party_table[ii]
+    if ent.IsFounder then
+      in_party = true
+    break
+    end
+  end
+  
+  -- if no, search assembly and then add to party
+  if not in_party then
+    local assemblyCount = GAME:GetPlayerAssemblyCount()
   
       for i = assemblyCount,1,-1 do
         p = GAME:GetPlayerAssemblyMember(i-1)
-		if p.IsFounder then
-		  GAME:RemovePlayerAssembly(i-1)
-		  GAME:AddPlayerTeam(p)
-		end
+    if p.IsFounder then
+      GAME:RemovePlayerAssembly(i-1)
+      GAME:AddPlayerTeam(p)
+    end
       end
-	end
-	
-	-- move everyone else into assembly
-	local partyCount = GAME:GetPlayerPartyCount()
+  end
+  
+  -- move everyone else into assembly
+  local partyCount = GAME:GetPlayerPartyCount()
     for i = partyCount,1,-1 do
       p = GAME:GetPlayerPartyMember(i-1)
-	  if not p.IsFounder then
-		GAME:RemovePlayerTeam(i-1)
-		GAME:AddPlayerAssembly(p)
-	  end
+    if not p.IsFounder then
+    GAME:RemovePlayerTeam(i-1)
+    GAME:AddPlayerAssembly(p)
     end
-	
-	-- make leader
-	GAME:SetTeamLeaderIndex(0)
-	-- update team
+    end
+  
+  -- make leader
+  GAME:SetTeamLeaderIndex(0)
+  -- update team
     COMMON.RespawnAllies()
-	
-	
+  
+  
     local noctowl = CH('Noctowl')
     local player = CH('PLAYER')
-	
-	local floor_record = 0
-	if SV.floor_records["guildmaster_trail-0"] ~= nil then
-	  floor_record = SV.floor_records["guildmaster_trail-0"]
-	end
   
-	
+  local floor_record = 0
+  if SV.floor_records["guildmaster_trail-0"] ~= nil then
+    floor_record = SV.floor_records["guildmaster_trail-0"]
+  end
+  
+  
     GAME:CutsceneMode(true)
     UI:SetSpeaker(STRINGS:Format("\\uE040"), true, "", -1, "", RogueEssence.Data.Gender.Unknown)
-	
+  
     local zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('guildmaster_trail')
-	if floor_record < 9 then
+  if floor_record < 9 then
       UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_001'], zone:GetColoredName()))
-	elseif floor_record < 19 then
-	  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_01_Line_001'], zone:GetColoredName()))
-	else
-	  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_02_Line_001'], zone:GetColoredName()))
-	end
+  elseif floor_record < 19 then
+    UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_01_Line_001'], zone:GetColoredName()))
+  else
+    UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_02_Line_001'], zone:GetColoredName()))
+  end
     --move the noctowl to a new position
     GROUND:TeleportTo(noctowl, 244, 286, Direction.Up)
     GAME:FadeIn(20)
@@ -250,11 +267,11 @@ function base_camp.BeginExposition()
   local name = ""
   while not ch do
     name = ""
-	while name == "" do
+  while name == "" do
       UI:NameMenu(STRINGS:FormatKey("INPUT_TEAM_TITLE"), "")
       UI:WaitForChoice()
       name = UI:ChoiceResult()
-	end
+  end
     --UI:WaitShowDialogue("I see... {0}? [Exactly.] [Actually, it's...]")
     
 
@@ -325,9 +342,9 @@ function base_camp.RewardDialogue()
   local noctowl = CH('Noctowl')
     
   GROUND:TeleportTo(noctowl, 244, 286, Direction.Up)
-	
+  
   GAME:FadeIn(20)
-	
+  
   UI:SetSpeaker(noctowl)
   
   UI:WaitShowDialogue("Your badge... that insignia!")
@@ -361,18 +378,47 @@ function base_camp.RewardDialogue()
 end
 
 --------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
+
+--------------------------------------------------
 -- Objects Callbacks
 --------------------------------------------------
 
-function base_camp.North_Exit_Touch(obj, activator)
+-- go take in any patched new dungeons and grouns and add them too!
+function base_camp.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  local dungeon_entrances = { 'tropical_path', 'faultline_ridge', 'guildmaster_trail' }
-  local ground_entrances = {{Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=0},
-  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=0},
-  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
-  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
-  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
-  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
+
+  -- do a deep clone to avoid shennaigans
+  -- improvement: cacheing of some sort, probs
+  local dungeon_entrances = helper.HelperDeepClone(CAMP_DUN_ENTRANCES)
+  -- merge these together
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  -- todo
+  -- table.sort(dungeon_entrance,somefuncforcolorsorting)
+
+-- same for ground
+  local ground_entrances = helper.HelperDeepClone(CAMP_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
@@ -387,7 +433,7 @@ function base_camp.First_North_Exit_Touch(obj, activator)
   ch = UI:ChoiceResult()
   if ch then
     _DATA:PreLoadZone('guildmaster_trail')
-	SOUND:PlayBGM("", true)
+  SOUND:PlayBGM("", true)
     GAME:FadeOut(false, 20)
     GAME:EnterDungeon('guildmaster_trail', 0, 0, 0, RogueEssence.Data.GameProgress.DungeonStakes.Risk, true, true)
   end
@@ -405,16 +451,30 @@ function base_camp.East_Exit_Touch(obj, activator)
   GAME:EnterGroundMap("base_camp_2", "entrance_west", true)
 end
 
-function base_camp.Ferry_Action(obj, activator)
+function base_camp.Ferry_Action(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   local ferry = CH('Lapras')
   UI:SetSpeaker(ferry)
   if not SV.base_camp.FerryIntroduced then
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_001']))
-	SV.base_camp.FerryIntroduced = true
+  SV.base_camp.FerryIntroduced = true
   end
-  local dungeon_entrances = { 'lava_floe_island', 'castaway_cave', 'eon_island', 'uncharted_waters', 'inscribed_cave', 'prism_isles' }
-  local ground_entrances = {}
+
+ -- do a deep clone to avoid shennaigans
+  -- improvement: cacheing of some sort, probs
+  local dungeon_entrances = helper.HelperDeepClone(FERRY_DUN_ENTRANCES)
+  -- merge these together
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  -- todo
+  -- table.sort(dungeon_entrance,somefuncforcolorsorting)
+
+-- same for ground
+  local ground_entrances = helper.HelperDeepClone(FERRY_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
+  -- work for entrances
+  local dungeon_entrances = FERRY_DUN_ENTRANCES
+  local ground_entrances = FERRY_GRO_ENTRANCES 
   
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_002']))
   
@@ -436,10 +496,10 @@ function base_camp.Sign_Action(obj, activator)
     UI:ChoiceMenuYesNo("UNLOCK THE HALF FINISHED STORY? NO TURNING OFF.", true)
     UI:WaitForChoice()
     ch = UI:ChoiceResult()
-	if ch then
-	  SV.Experimental = true
-	  UI:WaitShowDialogue("UNLOCKED")
-	end
+  if ch then
+    SV.Experimental = true
+    UI:WaitShowDialogue("UNLOCKED")
+  end
   end
 end
 
@@ -524,7 +584,7 @@ function base_camp.Catch_Action()
   
   GROUND:CharTurnToChar(player, catch2)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-	
+  
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch2)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_002']))
@@ -549,25 +609,25 @@ function base_camp.NPC_Steel_1_Action(chara, activator)
   
   local questname = "QuestSteel"
   local quest = SV.missions.Missions[questname]
-	
+  
   
   if quest == nil then
     UI:SetSpeaker(chara)
     GROUND:CharTurnToChar(chara,player)
-	UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Line_001']))
-	
-	COMMON.CreateMission(questname,
-	{ Complete = COMMON.MISSION_INCOMPLETE, Type = COMMON.SIDEQUEST_TYPE_RESCUE,
+  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Line_001']))
+  
+  COMMON.CreateMission(questname,
+  { Complete = COMMON.MISSION_INCOMPLETE, Type = COMMON.SIDEQUEST_TYPE_RESCUE,
       DestZone = "guildmaster_trail", DestSegment = 0, DestFloor = 14,
       FloorUnknown = false,
       TargetSpecies = RogueEssence.Dungeon.MonsterID("scizor", 0, "normal", Gender.Male),
       ClientSpecies = RogueEssence.Dungeon.MonsterID("steelix", 0, "normal", Gender.Male) }
-	  )
-	
+    )
+  
   elseif quest.Complete == COMMON.MISSION_INCOMPLETE then
     UI:SetSpeaker(chara)
     GROUND:CharTurnToChar(chara,player)
-	UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Line_002']))
+  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Line_002']))
   else
     base_camp.Steel_Complete()
   end
@@ -645,7 +705,7 @@ function base_camp.NPC_Coast_Action(chara, activator)
   if not SV.family.Mother and SV.family.MotherActiveDays >= 3 then
   
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Mother_Line_001']))
-	
+  
   else
 
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Outside_Line_001']))

--- a/Data/Script/origin/ground/canyon_camp/init.lua
+++ b/Data/Script/origin/ground/canyon_camp/init.lua
@@ -22,6 +22,28 @@ local WEST_GRO_ENTRANCES = {
 }
 
 --------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
+
+--------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
 function canyon_camp.Init(map)
@@ -310,7 +332,6 @@ end
 --------------------------------------------------
 -- Objects Callbacks
 --------------------------------------------------
-
 
   
 function canyon_camp.Rival_1_Action(chara, activator)
@@ -1187,9 +1208,9 @@ end
 function canyon_camp.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = helper.HelperClone(EAST_DUN_ENTRANCES)
+  local dungeon_entrances = helper.HelperDeepClone(EAST_DUN_ENTRANCES)
   helper.HelperMerge(dungeon_entrances,newDunEnts)
-  local ground_entrances = helper.HelperClone(EAST_GRO_ENTRANCES)
+  local ground_entrances = helper.HelperDeepClone(EAST_GRO_ENTRANCES)
   helper.HelperMerge(ground_entrances,newGroEnts)
 
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
@@ -1198,9 +1219,9 @@ end
 function canyon_camp.West_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = helper.HelperClone(WEST_DUN_ENTRANCES)
+  local dungeon_entrances = helper.HelperDeepClone(WEST_DUN_ENTRANCES)
   helper.HelperMerge(dungeon_entrances,newDunEnts)
-  local ground_entrances = helper.HelperClone(WEST_GRO_ENTRANCES)
+  local ground_entrances = helper.HelperDeepClone(WEST_GRO_ENTRANCES)
   helper.HelperMerge(ground_entrances,newGroEnts)
 
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)

--- a/Data/Script/origin/ground/canyon_camp/init.lua
+++ b/Data/Script/origin/ground/canyon_camp/init.lua
@@ -1,6 +1,25 @@
 require 'origin.common'
 
 local canyon_camp = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
+
+local EAST_DUN_ENTRANCES = { 'copper_quarry', 'depleted_basin', 'forsaken_desert',
+'relic_tower', 'sleeping_caldera', 'royal_halls', 'starfall_heights', 'wisdom_road', 'sacred_tower'}
+local EAST_GRO_ENTRANCES = {
+  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
+  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+local WEST_DUN_ENTRANCES = {}
+local WEST_GRO_ENTRANCES = {
+  {Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
+  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
+  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2}
+}
 
 --------------------------------------------------
 -- Map Callbacks
@@ -1165,23 +1184,25 @@ function canyon_camp.Aggron_Fail()
   --get back up
 end
 
-function canyon_camp.East_Exit_Touch(obj, activator)
+function canyon_camp.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = { 'copper_quarry', 'depleted_basin', 'forsaken_desert', 'relic_tower', 'sleeping_caldera', 'royal_halls', 'starfall_heights', 'wisdom_road', 'sacred_tower'}
-  local ground_entrances = {{Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
-  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
-  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
+  local dungeon_entrances = helper.HelperClone(EAST_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances,newDunEnts)
+  local ground_entrances = helper.HelperClone(EAST_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances,newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
-function canyon_camp.West_Exit_Touch(obj, activator)
+function canyon_camp.West_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = { }
-  local ground_entrances = {{Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
-  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
-  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2}}
+  local dungeon_entrances = helper.HelperClone(WEST_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances,newDunEnts)
+  local ground_entrances = helper.HelperClone(WEST_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances,newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 

--- a/Data/Script/origin/ground/canyon_camp/init.lua
+++ b/Data/Script/origin/ground/canyon_camp/init.lua
@@ -4,8 +4,6 @@ local canyon_camp = {}
 --------------------------------------------------
 -- Variables
 --------------------------------------------------
-local helper = {}
-
 local EAST_DUN_ENTRANCES = { 'copper_quarry', 'depleted_basin', 'forsaken_desert',
 'relic_tower', 'sleeping_caldera', 'royal_halls', 'starfall_heights', 'wisdom_road', 'sacred_tower'}
 local EAST_GRO_ENTRANCES = {
@@ -20,28 +18,6 @@ local WEST_GRO_ENTRANCES = {
   {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
   {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2}
 }
-
---------------------------------------------------
--- Helpers
---------------------------------------------------
--- these should probably be stuffed in some common location!
-function helper.HelperDeepClone(target)
-  local clone = {}
-  if target then
-    for i=1,#target do
-      clone[#clone+1] = target[i]
-    end
-  end
-  return clone
-end
-
-function helper.HelperMerge(tableAddedTo, tableTakenFrom)
-  if tableAddedTo and tableTakenFrom then
-    for i=1,#tableTakenFrom do
-      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
-    end
-  end
-end
 
 --------------------------------------------------
 -- Map Callbacks
@@ -1208,23 +1184,13 @@ end
 function canyon_camp.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = helper.HelperDeepClone(EAST_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances,newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(EAST_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances,newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, EAST_DUN_ENTRANCES, EAST_GRO_ENTRANCES)
 end
 
 function canyon_camp.West_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   
-  local dungeon_entrances = helper.HelperDeepClone(WEST_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances,newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(WEST_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances,newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, WEST_DUN_ENTRANCES, WEST_GRO_ENTRANCES)
 end
 
 

--- a/Data/Script/origin/ground/cliff_camp/init.lua
+++ b/Data/Script/origin/ground/cliff_camp/init.lua
@@ -4,8 +4,6 @@ local cliff_camp = {}
 --------------------------------------------------
 -- Variables
 --------------------------------------------------
-local helper = {}
-
 local EAST_DUN_ENTRANCES = {
 'fertile_valley', 'flyaway_cliffs', 'wayward_wetlands', 'deserted_fortress',
  'bravery_road', 'geode_crevice', 'the_sky' }
@@ -21,28 +19,6 @@ local WEST_GRO_ENTRANCES = {
   {Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
   {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2}
 }
---------------------------------------------------
--- Helpers
---------------------------------------------------
--- these should probably be stuffed in some common location!
-function helper.HelperDeepClone(target)
-  local clone = {}
-  if target then
-    for i=1,#target do
-      clone[#clone+1] = target[i]
-    end
-  end
-  return clone
-end
-
-function helper.HelperMerge(tableAddedTo, tableTakenFrom)
-  if tableAddedTo and tableTakenFrom then
-    for i=1,#tableTakenFrom do
-      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
-    end
-  end
-end
-
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
@@ -302,25 +278,14 @@ end
 --------------------------------------------------
 function cliff_camp.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
   
-  local dungeon_entrances = helper.HelperDeepClone(EAST_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(EAST_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances, ground_entrances)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, EAST_DUN_ENTRANCES, EAST_GRO_ENTRANCES)
 end
 
 function cliff_camp.West_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
-
-  local dungeon_entrances = helper.HelperDeepClone(WEST_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(WEST_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, WEST_DUN_ENTRANCES, WEST_GRO_ENTRANCES)
 end
 
 

--- a/Data/Script/origin/ground/cliff_camp/init.lua
+++ b/Data/Script/origin/ground/cliff_camp/init.lua
@@ -1,6 +1,47 @@
 require 'origin.common'
 
 local cliff_camp = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
+
+local EAST_DUN_ENTRANCES = {
+'fertile_valley', 'flyaway_cliffs', 'wayward_wetlands', 'deserted_fortress',
+ 'bravery_road', 'geode_crevice', 'the_sky' }
+local EAST_GRO_ENTRANCES = {
+  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
+  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
+  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+local WEST_DUN_ENTRANCES = {}
+local WEST_GRO_ENTRANCES = {
+  {Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
+  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2}
+}
+--------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
 
 --------------------------------------------------
 -- Map Callbacks
@@ -259,23 +300,26 @@ end
 --------------------------------------------------
 -- Objects Callbacks
 --------------------------------------------------
-function cliff_camp.East_Exit_Touch(obj, activator)
+function cliff_camp.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   UI:ResetSpeaker()
   
-  local dungeon_entrances = { 'fertile_valley', 'flyaway_cliffs', 'wayward_wetlands', 'deserted_fortress', 'bravery_road', 'geode_crevice', 'the_sky' }
-  local ground_entrances = {{Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
-  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
-  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
-  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  local dungeon_entrances = helper.HelperDeepClone(EAST_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(EAST_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
+  COMMON.ShowDestinationMenu(dungeon_entrances, ground_entrances)
 end
 
-function cliff_camp.West_Exit_Touch(obj, activator)
+function cliff_camp.West_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  local dungeon_entrances = { }
-  local ground_entrances = {{Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
-  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2}}
+  UI:ResetSpeaker()
+
+  local dungeon_entrances = helper.HelperDeepClone(WEST_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(WEST_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 

--- a/Data/Script/origin/ground/final_stop/init.lua
+++ b/Data/Script/origin/ground/final_stop/init.lua
@@ -1,6 +1,49 @@
 require 'origin.common'
 
 local final_stop = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
+
+-- north
+local NORTH_DUN_ENTRANCES = {
+'champions_road', 'barren_tundra', 'cave_of_solace', 'labyrinth_of_the_lost' }
+local NORTH_GRO_ENTRANCES = {
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+-- south
+local SOUTH_DUN_ENTRANCES = {}
+local SOUTH_GRO_ENTRANCES = {
+  {Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
+  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
+  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2},
+  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2},
+  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=2}
+}
+--------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
+
 
 --------------------------------------------------
 -- Map Callbacks
@@ -630,22 +673,27 @@ function final_stop.NPC_Forbidden_Action(chara, activator)
   end
 end
 
-function final_stop.North_Exit_Touch(obj, activator)
+function final_stop.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+  UI:ResetSpeaker()
   
-  local dungeon_entrances = { 'champions_road', 'barren_tundra', 'cave_of_solace', 'labyrinth_of_the_lost' }
-  local ground_entrances = {{Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
+  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+  
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
-function final_stop.South_Exit_Touch(obj, activator)
+function final_stop.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  local dungeon_entrances = { }
-  local ground_entrances = {{Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
-  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
-  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2},
-  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2},
-  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=2}}
+  UI:ResetSpeaker()
+
+  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 

--- a/Data/Script/origin/ground/final_stop/init.lua
+++ b/Data/Script/origin/ground/final_stop/init.lua
@@ -4,8 +4,6 @@ local final_stop = {}
 --------------------------------------------------
 -- Variables
 --------------------------------------------------
-local helper = {}
-
 -- north
 local NORTH_DUN_ENTRANCES = {
 'champions_road', 'barren_tundra', 'cave_of_solace', 'labyrinth_of_the_lost' }
@@ -22,28 +20,6 @@ local SOUTH_GRO_ENTRANCES = {
   {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2},
   {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=2}
 }
---------------------------------------------------
--- Helpers
---------------------------------------------------
--- these should probably be stuffed in some common location!
-function helper.HelperDeepClone(target)
-  local clone = {}
-  if target then
-    for i=1,#target do
-      clone[#clone+1] = target[i]
-    end
-  end
-  return clone
-end
-
-function helper.HelperMerge(tableAddedTo, tableTakenFrom)
-  if tableAddedTo and tableTakenFrom then
-    for i=1,#tableTakenFrom do
-      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
-    end
-  end
-end
-
 
 --------------------------------------------------
 -- Map Callbacks
@@ -675,26 +651,14 @@ end
 
 function final_stop.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
   
-  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-  
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, NORTH_DUN_ENTRANCES, NORTH_GRO_ENTRANCES)
 end
 
 function final_stop.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
-
-  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, SOUTH_DUN_ENTRANCES, SOUTH_GRO_ENTRANCES)
 end
 
 

--- a/Data/Script/origin/ground/forest_camp/init.lua
+++ b/Data/Script/origin/ground/forest_camp/init.lua
@@ -224,26 +224,14 @@ end
 --------------------------------------------------
 function forest_camp.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
   
-  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-  
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, NORTH_DUN_ENTRANCES, NORTH_GRO_ENTRANCES)
 end
 
 function forest_camp.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
-
-  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, SOUTH_DUN_ENTRANCES, SOUTH_GRO_ENTRANCES)
 end
 
 function forest_camp.Assembly_Action(obj, activator)

--- a/Data/Script/origin/ground/forest_camp/init.lua
+++ b/Data/Script/origin/ground/forest_camp/init.lua
@@ -1,7 +1,50 @@
 require 'origin.common'
 
 local forest_camp = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
 
+-- north
+local NORTH_DUN_ENTRANCES = {
+'faded_trail', 'bramble_woods', 'trickster_woods', 'overgrown_wilds', 
+'moonlit_courtyard', 'ambush_forest', 'tiny_tunnel', 'energy_garden',
+'sickly_hollow', 'secret_garden'}
+local NORTH_GRO_ENTRANCES = {
+  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=0},
+  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
+  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
+  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+-- south
+local SOUTH_DUN_ENTRANCES = {}
+local SOUTH_GRO_ENTRANCES = {
+  {Flag=true,Zone='guildmaster_island',ID=1,Entry=3}
+}
+--------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
@@ -179,22 +222,27 @@ end
 --------------------------------------------------
 -- Objects Callbacks
 --------------------------------------------------
-function forest_camp.North_Exit_Touch(obj, activator)
+function forest_camp.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  local dungeon_entrances = { 'faded_trail', 'bramble_woods', 'trickster_woods', 'overgrown_wilds', 'moonlit_courtyard', 'ambush_forest', 'tiny_tunnel', 'energy_garden', 'sickly_hollow', 'secret_garden'}
-  local ground_entrances = {{Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=0},
-  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=0},
-  {Flag=SV.rest_stop.ExpositionComplete,Zone='guildmaster_island',ID=6,Entry=0},
-  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
-  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
+  UI:ResetSpeaker()
+  
+  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+  
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
-function forest_camp.South_Exit_Touch(obj, activator)
+function forest_camp.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
-  local dungeon_entrances = { }
-  local ground_entrances = {{Flag=true,Zone='guildmaster_island',ID=1,Entry=3}}
+  UI:ResetSpeaker()
+
+  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
@@ -282,8 +330,6 @@ function forest_camp.NPC_Carry_Action(chara, activator)
     UI:SetSpeakerEmotion("Angry")
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Carry_Line_001']))
     UI:SetSpeakerEmotion("Stunned")
-	
-	--local skill_summary = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Skill]:Get("wake_up_slap")
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Carry_Line_002']))
     GROUND:EntTurn(chara, Direction.Left)
   elseif SV.supply_corps.Status >= 20 then

--- a/Data/Script/origin/ground/rest_stop/init.lua
+++ b/Data/Script/origin/ground/rest_stop/init.lua
@@ -4,8 +4,6 @@ local rest_stop = {}
 --------------------------------------------------
 -- Variables
 --------------------------------------------------
-local helper = {}
-
 -- north
 local NORTH_DUN_ENTRANCES = { 
 'thunderstruck_pass', 'veiled_ridge', 'snowbound_path', 
@@ -23,28 +21,6 @@ local SOUTH_GRO_ENTRANCES = {
   {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2},
   {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2}
 }
---------------------------------------------------
--- Helpers
---------------------------------------------------
--- these should probably be stuffed in some common location!
-function helper.HelperDeepClone(target)
-  local clone = {}
-  if target then
-    for i=1,#target do
-      clone[#clone+1] = target[i]
-    end
-  end
-  return clone
-end
-
-function helper.HelperMerge(tableAddedTo, tableTakenFrom)
-  if tableAddedTo and tableTakenFrom then
-    for i=1,#tableTakenFrom do
-      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
-    end
-  end
-end
-
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
@@ -833,29 +809,18 @@ end
 
 function rest_stop.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
   
-  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, NORTH_DUN_ENTRANCES, NORTH_GRO_ENTRANCES)
 
   --also dungeon 21: royal halls, is accessible by ???
   --also dungeon 22: cave of solace, is accessible by having 8 key items
-  
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+
 end
 
 function rest_stop.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  UI:ResetSpeaker()
-
-  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
-  helper.HelperMerge(dungeon_entrances, newDunEnts)
-  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
-  helper.HelperMerge(ground_entrances, newGroEnts)
-
-  COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
+  
+  COMMON.JuncPatchSupport(obj, activator, newDunEnts, newGroEnts, SOUTH_DUN_ENTRANCES, SOUTH_GRO_ENTRANCES)
 end
 
 function rest_stop.Assembly_Action(obj, activator)

--- a/Data/Script/origin/ground/rest_stop/init.lua
+++ b/Data/Script/origin/ground/rest_stop/init.lua
@@ -1,6 +1,49 @@
 require 'origin.common'
 
 local rest_stop = {}
+--------------------------------------------------
+-- Variables
+--------------------------------------------------
+local helper = {}
+
+-- north
+local NORTH_DUN_ENTRANCES = { 
+'thunderstruck_pass', 'veiled_ridge', 'snowbound_path', 
+'treacherous_mountain', 'hope_road', 'cave_of_whispers' }
+local NORTH_GRO_ENTRANCES = {
+  {Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
+  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}
+}
+
+-- south
+local SOUTH_DUN_ENTRANCES = {}
+local SOUTH_GRO_ENTRANCES = {
+  {Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
+  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
+  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2},
+  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2}
+}
+--------------------------------------------------
+-- Helpers
+--------------------------------------------------
+-- these should probably be stuffed in some common location!
+function helper.HelperDeepClone(target)
+  local clone = {}
+  if target then
+    for i=1,#target do
+      clone[#clone+1] = target[i]
+    end
+  end
+  return clone
+end
+
+function helper.HelperMerge(tableAddedTo, tableTakenFrom)
+  if tableAddedTo and tableTakenFrom then
+    for i=1,#tableTakenFrom do
+      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
+    end
+  end
+end
 
 --------------------------------------------------
 -- Map Callbacks
@@ -788,25 +831,30 @@ function rest_stop.Ice_Complete()
   SV.team_dark.Status = 5
 end
 
-function rest_stop.North_Exit_Touch(obj, activator)
+function rest_stop.North_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+  UI:ResetSpeaker()
   
-  local dungeon_entrances = { 'thunderstruck_pass', 'veiled_ridge', 'snowbound_path', 'treacherous_mountain', 'hope_road', 'cave_of_whispers' }
+  local dungeon_entrances = helper.HelperDeepClone(NORTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(NORTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
   --also dungeon 21: royal halls, is accessible by ???
   --also dungeon 22: cave of solace, is accessible by having 8 key items
-  local ground_entrances = {{Flag=SV.final_stop.ExpositionComplete,Zone='guildmaster_island',ID=7,Entry=0},
-  {Flag=SV.guildmaster_summit.GameComplete,Zone='guildmaster_island',ID=8,Entry=0}}
+  
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 
-function rest_stop.South_Exit_Touch(obj, activator)
+function rest_stop.South_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
-  local dungeon_entrances = { }
-  local ground_entrances = {{Flag=true,Zone='guildmaster_island',ID=1,Entry=3},
-  {Flag=SV.forest_camp.ExpositionComplete,Zone='guildmaster_island',ID=3,Entry=2},
-  {Flag=SV.cliff_camp.ExpositionComplete,Zone='guildmaster_island',ID=4,Entry=2},
-  {Flag=SV.canyon_camp.ExpositionComplete,Zone='guildmaster_island',ID=5,Entry=2}}
+  UI:ResetSpeaker()
+
+  local dungeon_entrances = helper.HelperDeepClone(SOUTH_DUN_ENTRANCES)
+  helper.HelperMerge(dungeon_entrances, newDunEnts)
+  local ground_entrances = helper.HelperDeepClone(SOUTH_GRO_ENTRANCES)
+  helper.HelperMerge(ground_entrances, newGroEnts)
+
   COMMON.ShowDestinationMenu(dungeon_entrances,ground_entrances)
 end
 


### PR DESCRIPTION
Changes to each camp/stop to support multi mod patching to junctions. This might break dungeon accessibility for current dungeon mods.

Here is an example of how to patch, with the target in this case being base_camp:
```
require 'origin.common'

local base_camp_resource_pack = {}

local base_junc = CURMAPSCR.East_Exit_Touch

function base_camp_resource_pack.East_Exit_Touch(obj, activator, newDunEnts, newGroEnts)
	local patchDuns = {'berry_grove'}
	local patchGros = {}


	-- clone sillies! i think this should handle cases where other mods add stuff
	local copy = function (target)
		local clone = {}
		if target then
		    for i=1,#target do
		      clone[#clone+1] = target[i]
		    end
	    end
	    return clone
	end

	local merge = function (tableAddedTo, tableTakenFrom)
		  if tableAddedTo and tableTakenFrom then
		    for i=1,#tableTakenFrom do
		      tableAddedTo[#tableAddedTo+1] = tableTakenFrom[i]
		    end
		  end
		end

	local dunEnts = copy(newDunEnts)
	merge(dunEnts,patchDuns)

	local groEnts = copy(newGroEnts)
	merge(groEnts,patchGros)

	GAME:UnlockDungeon('berry_grove')

	base_junc(obj, activator, dunEnts, groEnts)
end

return base_camp_resource_pack
```

Notes about these commits for future work:
- Patching is done by using CURMAPSCR in a particular way.
  - It's pretty specific, as recursion is part of how it works (to support other mods) - interface function should be created for modders to make the process easier.
- There are repeated helper functions in each script file that should be moved to somewhere else to be accessed commonly.
  - Ideally the process for junctions would also be moved into its own function in a separate file to avoid repeated code.
- I wanted to be able to sort the junction list by dungeon name colour, but this functionally hasn't been implemented yet. Would like to implement this while moving the common functions to their own file.
- A lot of merges and deep copies are made with these changes. This is currently not of much concern, but the way this is done may have to be changed in the future for runtime concerns.
  - Could cache all of the patch changes and generate the destination list upon loading the save file?