### PR TITLE
Fix for Dex Rater dialogue

### DIFF
--- a/Data/Script/origin/ground/cliff_camp/init.lua
+++ b/Data/Script/origin/ground/cliff_camp/init.lua
@@ -1204,7 +1204,7 @@ function cliff_camp.NPC_DexRater_Action(chara, activator)
 	end
 	
 	if SV.dex.CurrentRewardIdx <= #rewardReqs then
-	  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['DexRater_Next_001'], rewardReqs[SV.dex.CurrentRewardIdx]))
+		UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['DexRater_Next_001'], (rewardReqs[SV.dex.CurrentRewardIdx]).Req))
 	end
   end
   


### PR DESCRIPTION
Fixed the error in Audino's rating dialogue that caused them to reference an incorrect variable.