### PR TITLE
Patching support for non-junction warps

### DIFF
--- a/Data/Script/origin/ground/base_camp/init.lua
+++ b/Data/Script/origin/ground/base_camp/init.lua
@@ -24,25 +24,38 @@ base_camp.junction.ferry =
   groundmaps = {}
 }
 
+-- Base Town junction
+base_camp.junction.east =
+{
+	dungeons = {},
+  groundmaps = {{Flag=true,Zone="guildmaster_island", ID=2,Entry=0}}
+}
+
+-- Guild path junction
+base_camp.junction.west =
+{
+	dungeons = {},
+  groundmaps = {{Flag=true,Zone="guildmaster_island", ID=9,Entry=0}}
+}
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
 function base_camp.Init(map)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   PrintInfo("=>> Init_base_camp")
-  
+
   COMMON.RespawnAllies()
 end
 
 function base_camp.Enter(map)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
-  SV.checkpoint = 
+
+  SV.checkpoint =
   {
     Zone    = 'guildmaster_island', Segment  = -1,
     Map  = 1, Entry  = 0
   }
-  
+
   if SV.base_camp.CenterStatueDate and SV.base_camp.CenterStatueDate ~= "" then
     GROUND:Unhide("Statue_Center")
   end
@@ -52,12 +65,12 @@ function base_camp.Enter(map)
   if SV.base_camp.RightStatueDate and SV.base_camp.RightStatueDate ~= "" then
     GROUND:Unhide("Statue_Right")
   end
-  
+
   if SV.base_camp.FerryUnlocked then
     GROUND:Unhide("Lapras")
     GROUND:Unhide("Ferry")
   end
-  
+
   if not SV.base_camp.IntroComplete then
     base_camp.PrepareFirstTimeVisit()
     GAME:FadeIn(20)
@@ -65,20 +78,20 @@ function base_camp.Enter(map)
     base_camp.RewardDialogue()
     SV.guildmaster_trail.Rewarded = true
     SV.base_camp.ExpositionComplete = true
-  elseif not SV.base_camp.ExpositionComplete then	
+  elseif not SV.base_camp.ExpositionComplete then
     base_camp.SetupNpcs()
     base_camp.BeginExposition()
     SV.base_camp.ExpositionComplete = true
   else
     base_camp.SetupNpcs()
-	
+
     base_camp.CheckMissions()
-	
+
     GAME:FadeIn(20)
   end
-  
+
   SV.base_camp.IntroComplete = true
-  
+
 end
 
 --------------------------------------------------
@@ -93,7 +106,7 @@ function base_camp.PrepareFirstTimeVisit()
   GROUND:Unhide("West_LogPile")
   GROUND:Unhide("First_North_Exit")
   GAME:UnlockDungeon('guildmaster_trail')
-  
+
 end
 
 --------------------------------------------------
@@ -103,7 +116,7 @@ function base_camp.SetupNpcs()
   GROUND:Unhide("Noctowl")
   GROUND:Unhide("NPC_Coast")
   GROUND:Unhide("NPC_Entrance")
-  
+
   --Noctowl: 64, 252
   --Luxio: 104, 252
   if not SV.family.Sister and SV.family.SisterActiveDays >= 3 then
@@ -112,26 +125,26 @@ function base_camp.SetupNpcs()
 	GROUND:TeleportTo(noctowl, 64, 252, Direction.Right)
 	GROUND:TeleportTo(entrance, 104, 252, Direction.Left)
   end
-  
+
   --Wingull: 344, 264
   if not SV.family.Mother and SV.family.MotherActiveDays >= 3 then
 	local coast = CH('NPC_Coast')
 	GROUND:TeleportTo(coast, 232, 456, Direction.Down)
   end
-  
+
   if SV.team_catch.Status == 1 then
     GROUND:Unhide("NPC_Catch_1")
 	GROUND:Unhide("NPC_Catch_2")
   elseif SV.team_catch.Status == 4 then
     -- TODO cycling
   end
-  
+
   if SV.team_kidnapped.Status == 0 then
     GROUND:Unhide("NPC_Unlucky")
   elseif SV.team_kidnapped.Status == 6 then
     -- TODO cycling
   end
-  
+
   if SV.team_steel.DaysSinceArgue >= 2 and not SV.team_steel.Rescued then
     GROUND:Unhide("NPC_Steel_1")
     local questname = "QuestSteel"
@@ -142,12 +155,12 @@ function base_camp.SetupNpcs()
       GROUND:Unhide("NPC_Steel_2")
     end
   end
-  
+
   if SV.guildmaster_summit.GameComplete then
     local noctowl = CH('Noctowl')
     GROUND:TeleportTo(noctowl, 80, 288, Direction.Right)
   end
-  
+
   if not SV.family.Sister and SV.family.SisterActiveDays >= 3 then
 	local noctowl = CH('Noctowl')
 	local entrance = CH('NPC_Entrance')
@@ -159,29 +172,29 @@ end
 
 function base_camp.CheckMissions()
   local player = CH('PLAYER')
-  
+
   local quest = SV.missions.Missions["EscortMother"]
   if quest ~= nil then
     if quest.Complete == COMMON.MISSION_COMPLETE then
-	
-      --spawn her	  
-      
+
+      --spawn her
+
       GAME:FadeIn(20)
       UI:WaitShowDialogue("Escort mission state: Complete.")
-      
+
       --she walks off to sunflora
       UI:WaitShowDialogue("The mother drops something as she runs off.")
-      
+
       SV.magnagate.Cards = SV.magnagate.Cards + 1
 	  SV.family.Mother = true
       COMMON.GiftKeyItem(player, RogueEssence.StringKey("ITEM_KEY_CARD_WATER"):ToLocal())
 	  COMMON.CompleteMission("EscortMother")
-	  
+
     end
   end
 end
 
-function base_camp.BeginExposition()  
+function base_camp.BeginExposition()
 
 	-- move founder to team if not in party
 	-- get party
@@ -195,11 +208,11 @@ function base_camp.BeginExposition()
 		break
 	  end
 	end
-	
+
 	-- if no, search assembly and then add to party
 	if not in_party then
 	  local assemblyCount = GAME:GetPlayerAssemblyCount()
-  
+
       for i = assemblyCount,1,-1 do
         p = GAME:GetPlayerAssemblyMember(i-1)
 		if p.IsFounder then
@@ -208,7 +221,7 @@ function base_camp.BeginExposition()
 		end
       end
 	end
-	
+
 	-- move everyone else into assembly
 	local partyCount = GAME:GetPlayerPartyCount()
     for i = partyCount,1,-1 do
@@ -218,25 +231,25 @@ function base_camp.BeginExposition()
 		GAME:AddPlayerAssembly(p)
 	  end
     end
-	
+
 	-- make leader
 	GAME:SetTeamLeaderIndex(0)
 	-- update team
     COMMON.RespawnAllies()
-	
-	
+
+
     local noctowl = CH('Noctowl')
     local player = CH('PLAYER')
-	
+
 	local floor_record = 0
 	if SV.floor_records["guildmaster_trail-0"] ~= nil then
 	  floor_record = SV.floor_records["guildmaster_trail-0"]
 	end
-  
-	
+
+
     GAME:CutsceneMode(true)
     UI:SetSpeaker(STRINGS:Format("\\uE040"), true, "", -1, "", RogueEssence.Data.Gender.Unknown)
-	
+
     local zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('guildmaster_trail')
 	if floor_record < 9 then
       UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_001'], zone:GetColoredName()))
@@ -251,24 +264,24 @@ function base_camp.BeginExposition()
 
 
   UI:SetSpeaker(noctowl)
-  
+
   if floor_record < 19 then
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_002']))
   else
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_02_Line_002']))
   end
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_003']))
-  
+
   GROUND:CharSetEmote(player, "shock", 1)
   SOUND:PlayBattleSE("EVT_Emote_Shock_Bad")
   GAME:WaitFrames(60)
-  
+
   if floor_record < 19 then
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_004']))
   else
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Achieved_02_Line_004']))
   end
-    
+
   local ch = false
   local name = ""
   while not ch do
@@ -279,108 +292,108 @@ function base_camp.BeginExposition()
       name = UI:ChoiceResult()
 	end
     --UI:WaitShowDialogue("I see... {0}? [Exactly.] [Actually, it's...]")
-    
+
 
     UI:ChoiceMenuYesNo(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_005'], name), true)
     UI:WaitForChoice()
     ch = UI:ChoiceResult()
   end
-  
+
   GAME:SetTeamName(name)
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_006']))
-  
+
   local zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('guildmaster_trail')
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_007'], zone:GetColoredName()))
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_008']))
-  
+
   GROUND:EntTurn(player, Direction.DownRight)
   GROUND:MoveInDirection(noctowl, Direction.UpRight, 17, false, 2)
-  
+
   GROUND:EntTurn(player, Direction.Right)
   GROUND:EntTurn(noctowl, Direction.Left)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_009']))
-  
+
   GROUND:EntTurn(player, Direction.UpRight)
   GROUND:MoveInDirection(noctowl, Direction.UpLeft, 17, false, 2)
-  
+
   GROUND:EntTurn(player, Direction.Up)
   GROUND:EntTurn(noctowl, Direction.Down)
-  
+
   zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('tropical_path')
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_010'], zone:GetColoredName()))
-  
+
   --UI:WaitShowDialogue("It amazes me that the likes of you still come to this island.")
   --UI:WaitShowDialogue("I had believed the rush to explore this island died down years ago.")
-  
+
   --?
   GROUND:EntTurn(player, Direction.UpLeft)
   GROUND:MoveInDirection(noctowl, Direction.DownLeft, 17, false, 2)
-  
+
   GROUND:EntTurn(player, Direction.Left)
   GROUND:EntTurn(noctowl, Direction.Right)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Expo_Cutscene_Line_011']))
-  
-  
+
+
   GROUND:MoveInDirection(noctowl, Direction.Left, 101, false, 2)
   GROUND:EntTurn(noctowl, Direction.Right)
-  
-  
+
+
   UI:ResetSpeaker()
-  
+
   --walk to block off the main entrance
-  
+
   --speak, and then unlock the new dungeon
   GAME:UnlockDungeon('tropical_path')
   GAME:CutsceneMode(false)
-  
+
 end
 
 
 function base_camp.RewardDialogue()
-  
+
   GAME:CutsceneMode(true)
-  
+
   GROUND:Unhide("Noctowl")
-  
+
   local player = CH('PLAYER')
   local noctowl = CH('Noctowl')
-    
+
   GROUND:TeleportTo(noctowl, 244, 286, Direction.Up)
-	
+
   GAME:FadeIn(20)
-	
+
   UI:SetSpeaker(noctowl)
-  
+
   UI:WaitShowDialogue("Your badge... that insignia!")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Reward_Line_001']))
   --UI:WaitShowDialogue("Where did you come from...?")
   --UI:WaitShowDialogue("Could it be...?")
-  
+
   --UI:WaitShowDialogue("When the guildmasters first put up the challenge, I was there.")
   --UI:WaitShowDialogue("I witnessed them set off for the summit, never to return.")
   --UI:WaitShowDialogue("Countless others followed, but never succeeded.")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Reward_Line_002']))
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Reward_Line_003']))
-  
+
   local receive_item = RogueEssence.Dungeon.InvItem("apricorn_perfect")
   COMMON.GiftItem(player, receive_item)
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Reward_Line_004']))
-  
+
   GROUND:MoveToPosition(noctowl, 82, 286, false, 2)
-  
+
   GROUND:MoveToPosition(noctowl, 80, 288, false, 2)
-  
+
   GROUND:CharAnimateTurnTo(noctowl, Direction.Right, 4)
-  
+
   GAME:UnlockDungeon('tropical_path')
-  
-  
+
+
   GAME:CutsceneMode(false)
-  
+
 end
 
 --------------------------------------------------
@@ -392,9 +405,9 @@ function base_camp.North_Exit_Touch(obj, activator)
   COMMON.ShowDestinationMenu(base_camp.junction.north.dungeons, base_camp.junction.north.groundmaps)
 end
 
-function base_camp.First_North_Exit_Touch(obj, activator)  
+function base_camp.First_North_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   UI:ResetSpeaker(false)
   SOUND:PlaySE("Menu/Skip")
   local zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('guildmaster_trail')
@@ -410,14 +423,26 @@ function base_camp.First_North_Exit_Touch(obj, activator)
 end
 function base_camp.West_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("guild_path", "entrance_east")
+
+  -- check if patched
+  if((#base_camp.junction.west.dungeons == 0) and (#base_camp.junction.west.groundmaps == 1)) then
+    GAME:FadeOut(false, 20)
+    GAME:EnterGroundMap("guild_path", "entrance_east")
+  else
+      COMMON.ShowDestinationMenu(base_camp.junction.west.dungeons, base_camp.junction.west.groundmaps)
+  end
 end
 
 function base_camp.East_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("base_camp_2", "entrance_west", true)
+
+  -- check if patched
+  if((#base_camp.junction.east.dungeons == 0) and (#base_camp.junction.east.groundmaps == 1)) then
+    GAME:FadeOut(false, 20)
+    GAME:EnterGroundMap("base_camp_2", "entrance_west", true)
+    else
+      COMMON.ShowDestinationMenu(base_camp.junction.east.dungeons, base_camp.junction.east.groundmaps)
+    end
 end
 
 function base_camp.Ferry_Action(obj, activator)
@@ -428,9 +453,9 @@ function base_camp.Ferry_Action(obj, activator)
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_001']))
 	SV.base_camp.FerryIntroduced = true
   end
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Ferry_Line_002']))
-  
+
   COMMON.ShowDestinationMenu(base_camp.junction.ferry.dungeons,base_camp.junction.ferry.groundmaps, true,
   ferry,
   STRINGS:Format(STRINGS.MapStrings['Ferry_Line_003']))
@@ -443,7 +468,7 @@ function base_camp.Sign_Action(obj, activator)
   UI:SetAutoFinish(true)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Sign_Action_Text']))
   UI:SetAutoFinish(false)
-  
+
   base_camp.sign_count = base_camp.sign_count + 1
   if base_camp.sign_count > 5 and SV.Experimental ~= true then
     UI:ChoiceMenuYesNo("UNLOCK THE HALF FINISHED STORY? NO TURNING OFF.", true)
@@ -471,18 +496,18 @@ function base_camp.Noctowl_Action(chara, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
-  
+
   if not SV.base_camp.FirstTalkComplete and _DATA.Save:GetDungeonUnlock("champions_road") ~= RogueEssence.Data.GameProgress.UnlockState.Completed and SV.guildmaster_summit.GameComplete then
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Action_Line_001']))
     SV.base_camp.FirstTalkComplete = true
   end
-  
+
   local tutorial_choices = {STRINGS:FormatKey("DLG_CHOICE_YES"),
     STRINGS:FormatKey("MENU_INFO"),
     STRINGS:FormatKey("DLG_CHOICE_NO")}
-  
+
   local zone = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:Get('training_maze')
-  
+
   local result = 2
   while result == 2 do
     UI:BeginChoiceMenu(STRINGS:Format(STRINGS.MapStrings['Noctowl_Ask_Tutorial'], zone:GetColoredName()), tutorial_choices, 1, 3)
@@ -501,30 +526,30 @@ function base_camp.Noctowl_Action(chara, activator)
       UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Noctowl_Tutorial_Line_003']))
     end
   end
-  
+
 end
 
 
 function base_camp.NPC_Catch_1_Action(chara, activator)
   DEBUG.EnableDbgCoro()
-  
+
   base_camp.Catch_Action()
 end
 
 function base_camp.NPC_Catch_2_Action(chara, activator)
   DEBUG.EnableDbgCoro()
   base_camp.Catch_Action()
-  
+
 end
 
 function base_camp.Catch_Action()
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local catch1 = CH('NPC_Catch_1')
   local catch2 = CH('NPC_Catch_2')
   local player = CH('PLAYER')
   local itemAnim = nil
-  
+
   GROUND:CharTurnToChar(player, catch1)
   UI:SetSpeaker(catch1)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_001']))
@@ -534,10 +559,10 @@ function base_camp.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch1.Bounds.Center, catch2.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch2)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-	
+
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch2)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_002']))
@@ -547,29 +572,29 @@ function base_camp.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch2.Bounds.Center, catch1.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch1)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-  
+
   SOUND:PlayBattleSE("DUN_Equip")
-  
+
   SV.team_catch.SpokenTo = true
 end
 
 function base_camp.NPC_Steel_1_Action(chara, activator)
 
   local player = CH('PLAYER')
-  
+
   if not SV.team_steel.Rescued then
     local questname = "QuestSteel"
     local quest = SV.missions.Missions[questname]
-    
-    
+
+
     if quest == nil then
       UI:SetSpeaker(chara)
       GROUND:CharTurnToChar(chara,player)
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Line_001']))
-    
+
     COMMON.CreateMission(questname,
     { Complete = COMMON.MISSION_INCOMPLETE, Type = COMMON.SIDEQUEST_TYPE_RESCUE,
         DestZone = "guildmaster_trail", DestSegment = 0, DestFloor = 14,
@@ -577,7 +602,7 @@ function base_camp.NPC_Steel_1_Action(chara, activator)
         TargetSpecies = RogueEssence.Dungeon.MonsterID("scizor", 0, "normal", Gender.Male),
         ClientSpecies = RogueEssence.Dungeon.MonsterID("steelix", 0, "normal", Gender.Male) }
       )
-    
+
     elseif quest.Complete == COMMON.MISSION_INCOMPLETE then
       UI:SetSpeaker(chara)
       GROUND:CharTurnToChar(chara,player)
@@ -588,7 +613,7 @@ function base_camp.NPC_Steel_1_Action(chara, activator)
   else
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_1_Finished_Line_001']))
   end
-  
+
 end
 
 function base_camp.NPC_Steel_2_Action(chara, activator)
@@ -603,20 +628,20 @@ function base_camp.Steel_Complete()
   local steel1 = CH('NPC_Steel_1')
   local steel2 = CH('NPC_Steel_2')
   local player = CH('PLAYER')
-  
+
   GROUND:CharTurnToChar(steel1,player)
   GROUND:CharTurnToChar(steel2,player)
-  
+
   UI:SetSpeaker(steel1)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Steel_Complete_Line_001']))
-  
+
   local receive_item = RogueEssence.Dungeon.InvItem("xcl_element_steel_silk")
   COMMON.GiftItem(player, receive_item)
-  
+
   UI:SetSpeaker(steel2)
-  
+
   COMMON.CompleteMission("QuestSteel")
-  
+
   SV.team_steel.Rescued = true
 end
 
@@ -625,30 +650,30 @@ function base_camp.NPC_Entrance_Action(chara, activator)
 
   if not SV.family.Sister and SV.family.SisterActiveDays >= 3 then
   local noctowl = CH('Noctowl')
-  
+
   UI:SetSpeaker(chara)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Sister_Line_001']))
-  
+
   UI:SetSpeaker(noctowl)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Sister_Line_002']))
-  
+
   UI:SetSpeaker(chara)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Sister_Line_003']))
-  
+
   UI:SetSpeaker(noctowl)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Sister_Line_004']))
-  
+
   UI:SetSpeaker(chara)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Sister_Line_005']))
   else
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Warn_Line_001']))
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Warn_Line_002']))
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Warn_Line_003']))
-  
+
   end
 end
 
@@ -658,13 +683,13 @@ function base_camp.NPC_Coast_Action(chara, activator)
   UI:SetSpeaker(chara)
 
   if not SV.family.Mother and SV.family.MotherActiveDays >= 3 then
-  
+
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Hint_Mother_Line_001']))
-	
+
   else
 
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Outside_Line_001']))
-  
+
   end
   GROUND:EntTurn(chara, Direction.Down)
 end
@@ -673,23 +698,23 @@ function base_camp.NPC_Unlucky_Action(chara, activator)
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
   UI:SetSpeakerEmotion("Worried")
-  
-  
+
+
   SOUND:PlayBattleSE("EVT_Emote_Sweating")
   GROUND:CharSetEmote(chara, "sweating", 1)
   GAME:WaitFrames(30)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Unlucky_Line_001']))
   UI:SetSpeakerEmotion("Sad")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Unlucky_Line_002']))
-  
-  
+
+
   if SV.Experimental then
     SV.team_kidnapped.SpokenTo = true
   end
 end
 
 function base_camp.Statue_Center_Action(obj, activator)
-  
+
   UI:ResetSpeaker()
   UI:SetAutoFinish(true)
   UI:SetCenter(true)
@@ -699,7 +724,7 @@ function base_camp.Statue_Center_Action(obj, activator)
 end
 
 function base_camp.Statue_Left_Action(obj, activator)
-  
+
   UI:ResetSpeaker()
   UI:SetAutoFinish(true)
   UI:SetCenter(true)
@@ -709,7 +734,7 @@ function base_camp.Statue_Left_Action(obj, activator)
 end
 
 function base_camp.Statue_Right_Action(obj, activator)
-  
+
   UI:ResetSpeaker()
   UI:SetAutoFinish(true)
   UI:SetCenter(true)

--- a/Data/Script/origin/ground/base_camp_2/init.lua
+++ b/Data/Script/origin/ground/base_camp_2/init.lua
@@ -5,6 +5,23 @@ local base_camp_2_juice = require 'origin.ground.base_camp_2.base_camp_2_juice'
 
 local base_camp_2 = {}
 
+-- Tables for the junctions on this map
+base_camp_2.junction = {}
+
+-- West - standard entrance
+base_camp_2.junction.west =
+{
+	dungeons = {},
+	groundmaps = {{Flag=true,Zone="guildmaster_island", ID=1, Entry=1}}
+}
+
+-- North - evolution area
+base_camp_2.junction.north =
+{
+	dungeons = {},
+	groundmaps = {{Flag=true,Zone="guildmaster_island", ID=11, Entry=0}}
+}
+
 
 --------------------------------------------------
 -- Map Callbacks
@@ -17,25 +34,25 @@ function base_camp_2.Init(map)
 
   --get assembly ready
   local assemblyCount = GAME:GetPlayerAssemblyCount()
-  
+
   local total = assemblyCount
   if total > 26 then
     total = 26
   end
-  
+
   --Place player teammates
   for i = 1,total,1 do
     GROUND:RemoveCharacter("Assembly" .. tostring(i))
   end
   --TODO: randomly add the spawns
-  
+
   for i = 1,total,1 do
     p = GAME:GetPlayerAssemblyMember(i-1)
     GROUND:SpawnerSetSpawn("ASSEMBLY_" .. tostring(i),p)
     local chara = GROUND:SpawnerDoSpawn("ASSEMBLY_" .. tostring(i))
     --GROUND:GiveCharIdleChatter(chara)
   end
-  
+
   COMMON.CreateWalkArea("Assembly" .. tostring(2), 424, 384, 48, 48)
   COMMON.CreateWalkArea("Assembly" .. tostring(4), 576, 272, 56, 64)
   COMMON.CreateWalkArea("Assembly" .. tostring(5), 336, 208, 64, 80)
@@ -45,12 +62,12 @@ function base_camp_2.Init(map)
   COMMON.CreateWalkArea("Assembly" .. tostring(14), 72, 264, 64, 64)
   COMMON.CreateWalkArea("Assembly" .. tostring(19), 400, 592, 56, 40)
   COMMON.CreateWalkArea("Assembly" .. tostring(22), 728, 352, 64, 48)
-  
+
   COMMON.CreateWalkArea("NPC_Food", 144, 592, 32, 32)
   COMMON.CreateWalkArea("NPC_Settling", 344, 288, 48, 48)
-  
+
   local can_talk_to = false
-  
+
   if total >= 3 then
     local talk_to = CH('Assembly3')
     --local tbl = LTBL(talk_to)
@@ -60,24 +77,24 @@ function base_camp_2.Init(map)
 	  end
 	end
   end
-  
+
   if can_talk_to then
     local talker = CH('NPC_Interactive')
 	GROUND:EntTurn(talker, Direction.UpRight)
   end
-  
+
   if SOUND:GetCurrentSong() ~= SV.base_town.Song then
     SOUND:PlayBGM(SV.base_town.Song, true)
   end
-  
+
   GROUND:AddMapStatus("clouds_overhead")
 end
 
 function base_camp_2.Enter(map)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   base_camp_2.SetupNpcs()
-  
+
   GAME:FadeIn(20)
 end
 
@@ -88,15 +105,15 @@ function base_camp_2.SetupNpcs()
   GROUND:Unhide("NPC_Food")
   GROUND:Unhide("NPC_Queen")
   GROUND:Unhide("NPC_King")
-  
+
   GROUND:Unhide("NPC_Treasure")
   GROUND:Unhide("NPC_Settling")
   GROUND:Unhide("NPC_Nonbeliever")
   GROUND:Unhide("NPC_Hesitant")
 
-  
+
   if SV.base_town.JuiceShop == 1 then
-    
+
 	local questname = "QuestBug"
     local quest = SV.missions.Missions[questname]
 	if quest == nil then
@@ -110,12 +127,12 @@ function base_camp_2.SetupNpcs()
   elseif SV.team_hunter.Status == 3 then
     -- TODO cycling
   end
-  
+
   if SV.team_hunter.Status > 0 and SV.base_town.JuiceShop >= 2 then
     local hesitant = CH('NPC_Hesitant')
     GROUND:EntTurn(hesitant, Direction.Up)
   end
-  
+
   if SV.team_hunter.Status > 0 and SV.base_town.JuiceShop >= 2 and SV.forest_camp.SnorlaxPhase >= 4 then
     GROUND:Unhide("Snorlax")
   end
@@ -158,7 +175,7 @@ function base_camp_2.SetupNpcs()
       GROUND:Unhide("NPC_Storehouse")
     end
   end
-  
+
   -- family appears if Returned = false
   if SV.family.Returned == false then
     -- and if they've been saved individually
@@ -189,12 +206,12 @@ end
 
 
 function base_camp_2.Family_Sister_Action(obj, activator)
-  
+
   local group_check = base_camp_2.Isekai_Event()
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -208,7 +225,7 @@ function base_camp_2.Family_Mother_Action(obj, activator)
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -222,7 +239,7 @@ function base_camp_2.Family_Father_Action(obj, activator)
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -236,7 +253,7 @@ function base_camp_2.Family_Brother_Action(obj, activator)
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -250,7 +267,7 @@ function base_camp_2.Family_Pet_Action(obj, activator)
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -264,7 +281,7 @@ function base_camp_2.Family_Grandma_Action(obj, activator)
   if group_check then
     return
   end
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
 
@@ -273,7 +290,7 @@ function base_camp_2.Family_Grandma_Action(obj, activator)
 end
 
 function base_camp_2.Isekai_Event()
-  
+
   if SV.family.TalkedReturn == false then
     if SV.guild_hut.TookCard then
 		UI:ResetSpeaker()
@@ -293,7 +310,7 @@ function base_camp_2.Isekai_Event()
 	  return true
 	end
   end
-  
+
   return false
 end
 
@@ -318,7 +335,7 @@ function base_camp_2.NPC_Treasure_Action(chara, activator)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Treasure_Line_001']))
   UI:SetSpeakerEmotion("Worried")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Treasure_Line_002']))
-  
+
 end
 
 
@@ -335,22 +352,22 @@ end
 
 function base_camp_2.NPC_Storehouse_Action(chara, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local player = CH('PLAYER')
   UI:SetSpeaker(chara)
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Storehouse_Line_Route']))
 end
 
 
 function base_camp_2.NPC_Carry_Action(chara, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local player = CH('PLAYER')
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
-  
+
   local ground = _DATA:GetGround("canyon_camp")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Carry_Line_001'], ground:GetColoredName(), _ZONE.CurrentGround:GetColoredName()))
 end
@@ -358,13 +375,13 @@ end
 
 function base_camp_2.NPC_Deliver_Action(chara, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local player = CH('PLAYER')
   local shopkeeper = CH('Shop_Owner')
-  
+
   GROUND:CharTurnToChar(chara,CH('PLAYER'))
   UI:SetSpeaker(chara)
-  
+
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Deliver_Line_001'], shopkeeper:GetDisplayName()))
 end
 
@@ -389,7 +406,7 @@ end
 
 
 function base_camp_2.Snorlax_Action(chara, activator)
-  
+
   UI:SetSpeaker(chara)
   UI:SetSpeakerEmotion("Happy")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Snorlax_Line_001']))
@@ -400,7 +417,7 @@ end
 
 function base_camp_2.NPC_Hesitant_Action(chara, activator)
   UI:SetSpeaker(chara)
-  
+
   if SV.team_hunter.Status > 0 and SV.base_town.JuiceShop >= 2 then
     GROUND:CharTurnToChar(chara,CH('PLAYER'))
     local herb = RogueEssence.Dungeon.InvItem("herb_white")
@@ -417,13 +434,13 @@ function base_camp_2.NPC_Elder_Action(chara, activator)
   UI:SetSpeaker(chara)
 
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Elder_Line_001']))
-  
+
   if SV.Experimental then
     SV.town_elder.SpokenTo = true
   end
-  
+
   --TODO: make him do something else after his mission?
-  
+
 end
 
 
@@ -432,24 +449,24 @@ function base_camp_2.NPC_Solo_Action(chara, activator)
 
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Solo_Line_001']))
   GROUND:CharAnimateTurnTo(chara, Direction.Down, 4)
-  
+
   GAME:WaitFrames(30)
   GROUND:CharSetEmote(chara, "happy", 3)
   local animId = RogueEssence.Content.GraphicsManager.GetAnimIndex("Pose")
   GROUND:CharSetAction(chara, RogueEssence.Ground.PoseGroundAction(chara.Position, chara.Direction, animId))
   UI:SetSpeakerEmotion("Determined")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Solo_Line_002']))
-  
+
   chara.CollisionDisabled = true
-  
+
   GROUND:MoveToPosition(chara, 760, 288, true, 4)
   GROUND:MoveToPosition(chara, 688, 360, true, 4)
   GROUND:MoveToPosition(chara, 576, 360, true, 4)
 
   GROUND:Hide("NPC_Solo")
-  
+
   SV.team_solo.SpokenTo = true
-  
+
 end
 
 
@@ -472,24 +489,24 @@ end
 
 function base_camp_2.NPC_Catch_1_Action(chara, activator)
   DEBUG.EnableDbgCoro()
-  
+
   base_camp_2.Catch_Action()
 end
 
 function base_camp_2.NPC_Catch_2_Action(chara, activator)
   DEBUG.EnableDbgCoro()
   base_camp_2.Catch_Action()
-  
+
 end
 
 function base_camp_2.Catch_Action()
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local catch1 = CH('NPC_Catch_1')
   local catch2 = CH('NPC_Catch_2')
   local player = CH('PLAYER')
   local itemAnim = nil
-  
+
   GROUND:CharTurnToChar(player, catch1)
   UI:SetSpeaker(catch1)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_001']))
@@ -499,10 +516,10 @@ function base_camp_2.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch1.Bounds.Center, catch2.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch2)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-	
+
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch2)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_002']))
@@ -512,10 +529,10 @@ function base_camp_2.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch2.Bounds.Center, catch1.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch1)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-  
+
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch1)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_003']))
@@ -525,10 +542,10 @@ function base_camp_2.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch1.Bounds.Center, catch2.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch2)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-  
+
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch2)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_004']))
@@ -538,20 +555,20 @@ function base_camp_2.Catch_Action()
   SOUND:PlayBattleSE("DUN_Throw_Arc")
   itemAnim = RogueEssence.Content.ItemAnim(catch2.Bounds.Center, catch1.Bounds.Center, "Rock_Gray", 48, 1)
   GROUND:PlayVFXAnim(itemAnim, RogueEssence.Content.DrawLayer.Normal)
-  
+
   GROUND:CharTurnToChar(player, catch1)
   GAME:WaitFrames(RogueEssence.Content.ItemAnim.ITEM_ACTION_TIME)
-  
+
   SOUND:PlayBattleSE("DUN_Equip")
   UI:SetSpeaker(catch1)
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Catch_Line_005']))
-  
-  
+
+
   if SV.Experimental then
     SV.team_catch.SpokenTo = true
   end
-  
-  
+
+
   -- TODO cycling
 end
 
@@ -593,11 +610,11 @@ base_camp_2.difficulty_tbl["bramble_woods"] = 1
 base_camp_2.difficulty_tbl["sickly_hollow"] = 1
 
 function base_camp_2.NPC_Interactive_Action(chara, activator)
-  
+
   local assemblyCount = GAME:GetPlayerAssemblyCount()
   UI:SetSpeaker(chara)
-  
-  
+
+
   local can_talk_to = false
   if assemblyCount >= 3 then
     talk_to = CH('Assembly3')
@@ -628,29 +645,29 @@ function base_camp_2.NPC_Interactive_Action(chara, activator)
 	    UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Interactive_Phase_004_Line_002'], cur_team))
 	  else
         UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Interactive_Phase_005_Line_001'], zone_name))
-		
+
         GAME:WaitFrames(30)
         GROUND:CharSetEmote(chara, "shock", 1)
         SOUND:PlayBattleSE("EVT_Emote_Shock_Bad")
         GAME:WaitFrames(30)
-  
+
         UI:SetSpeakerEmotion("Surprised")
         UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Interactive_Phase_005_Line_002'], cur_team))
 	  end
 	end
   end
-  
+
   if not can_talk_to then
     GROUND:CharTurnToChar(chara,CH('PLAYER'))
 	UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Interactive_Line_001']))
   end
-  
+
 end
 
 
 function base_camp_2.Shop_Action(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local state = 0
   local repeated = false
   local cart = {}
@@ -660,11 +677,11 @@ function base_camp_2.Shop_Action(obj, activator)
 	local item_data = { Item = RogueEssence.Dungeon.InvItem(base_data.Index, false, base_data.Amount), Price = base_data.Price }
 	table.insert(catalog, item_data)
   end
-  
-  
+
+
   local chara = CH('Shop_Owner')
   UI:SetSpeaker(chara)
-  
+
 	while state > -1 do
 		if state == 0 then
 			local msg = STRINGS:Format(STRINGS.MapStrings['Shop_Intro'])
@@ -746,7 +763,7 @@ function base_camp_2.Shop_Action(obj, activator)
 				UI:ChoiceMenuYesNo(msg, false)
 				UI:WaitForChoice()
 				result = UI:ChoiceResult()
-				
+
 				if result then
 					GAME:RemoveFromPlayerMoney(total)
 					for ii = 1, #cart, 1 do
@@ -757,7 +774,7 @@ function base_camp_2.Shop_Action(obj, activator)
 						table.remove(catalog, cart[ii])
 						table.remove(SV.base_shop, cart[ii])
 					end
-					
+
 					cart = {}
 					SOUND:PlayBattleSE("DUN_Money")
 					UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Shop_Buy_Complete']))
@@ -770,7 +787,7 @@ function base_camp_2.Shop_Action(obj, activator)
 			UI:SellMenu()
 			UI:WaitForChoice()
 			local result = UI:ChoiceResult()
-			
+
 			if #result > 0 then
 				cart = result
 				state = 4
@@ -803,7 +820,7 @@ function base_camp_2.Shop_Action(obj, activator)
 			UI:ChoiceMenuYesNo(msg, false)
 			UI:WaitForChoice()
 			result = UI:ChoiceResult()
-			
+
 			if result then
 				for ii = #cart, 1, -1 do
 					if cart[ii].IsEquipped then
@@ -827,7 +844,7 @@ end
 
 function base_camp_2.Appraisal_Action(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local state = 0
   local repeated = false
   local cart = {}
@@ -868,7 +885,7 @@ function base_camp_2.Appraisal_Action(obj, activator)
 			UI:AppraiseMenu()
 			UI:WaitForChoice()
 			local result = UI:ChoiceResult()
-			
+
 			if #result > 0 then
 				cart = result
 				state = 2
@@ -877,7 +894,7 @@ function base_camp_2.Appraisal_Action(obj, activator)
 			end
 		elseif state == 2 then
 			local total = #cart * price
-			
+
 			if total > GAME:GetPlayerMoney() then
 				UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_No_Money']))
 				state = 1
@@ -896,14 +913,14 @@ function base_camp_2.Appraisal_Action(obj, activator)
 				else
 					UI:SetSpeakerEmotion("Surprised")
 					msg = STRINGS:Format(STRINGS.MapStrings['Appraisal_Choose_Max'], STRINGS:FormatKey("MONEY_AMOUNT", total))
-					
+
 				end
 				UI:ChoiceMenuYesNo(msg, false)
 				UI:WaitForChoice()
 				result = UI:ChoiceResult()
-				
+
 				UI:SetSpeakerEmotion("Normal")
-				
+
 				local treasure = {}
 				if result then
 					for ii = #cart, 1, -1 do
@@ -916,12 +933,12 @@ function base_camp_2.Appraisal_Action(obj, activator)
 							box = GAME:GetPlayerBagItem(cart[ii].Slot)
 							GAME:TakePlayerBagItem(cart[ii].Slot, true)
 						end
-						
+
 						local treasure_item = box.HiddenValue
 						local itemEntry = _DATA:GetItem(treasure_item)
 						local treasure_choice = { Box = box, Item = RogueEssence.Dungeon.InvItem(treasure_item,false,itemEntry.MaxStack)}
 						table.insert(treasure, treasure_choice)
-						
+
 						-- note high rarity items
 						if itemEntry.Rarity > 0 then
 							SV.unlocked_trades[treasure_item] = true
@@ -930,10 +947,10 @@ function base_camp_2.Appraisal_Action(obj, activator)
 					SOUND:PlayBattleSE("DUN_Money")
 					GAME:RemoveFromPlayerMoney(total)
 					cart = {}
-					
+
 					if #treasure >= 24 then
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_Start_Max']))
-					
+
 					  GROUND:MoveInDirection(chara, Direction.Up, 18, false, 2)
 					  GROUND:Hide("Appraisal_Owner")
 					  GAME:WaitFrames(10)
@@ -971,14 +988,14 @@ function base_camp_2.Appraisal_Action(obj, activator)
 					  SOUND:PlayBattleSE("DUN_Explosion")
 					  TASK:JoinCoroutines({coro1})
 					  GAME:WaitFrames(30)
-					  
+
 					  emitter = RogueEssence.Content.StaticAreaEmitter(RogueEssence.Content.AnimData("Smoke_White", 3))
 					  emitter.Range = 72
 					  emitter.Bursts = 30
 					  emitter.BurstTime = 2
 					  emitter.ParticlesPerBurst = 1
 					  GROUND:PlayVFX(emitter, chara.MapLoc.X, chara.MapLoc.Y - 32)
-					  
+
 					  GAME:WaitFrames(30)
 					  GAME:FadeIn(60)
 					  GROUND:Unhide("Appraisal_Owner")
@@ -986,10 +1003,10 @@ function base_camp_2.Appraisal_Action(obj, activator)
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_End_Max_001']))
 					  SOUND:PlayFanfare("Fanfare/Treasure")
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_End_Max_002']))
-					
+
 					elseif #treasure >= 8 then
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_Start_002']))
-					
+
 					  GROUND:MoveInDirection(chara, Direction.Up, 18, false, 2)
 					  GROUND:Hide("Appraisal_Owner")
 					  GAME:WaitFrames(20)
@@ -1007,7 +1024,7 @@ function base_camp_2.Appraisal_Action(obj, activator)
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_End']))
 					else
 					  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Appraisal_Start_001']))
-					
+
 					  GROUND:MoveInDirection(chara, Direction.Up, 18, false, 2)
 					  GROUND:Hide("Appraisal_Owner")
 					  GAME:WaitFrames(10)
@@ -1023,13 +1040,13 @@ function base_camp_2.Appraisal_Action(obj, activator)
 
 					UI:SpoilsMenu(treasure)
 					UI:WaitForChoice()
-					
+
 					for ii = 1, #treasure, 1 do
 						local item = treasure[ii].Item
-						
+
 						GAME:GivePlayerItem(item.ID, item.Amount, false, item.HiddenValue)
 					end
-					
+
 					state = 0
 				else
 					state = 1
@@ -1041,7 +1058,7 @@ end
 
 function base_camp_2.Compute_Swap_Catalog()
   --silk/dust/gem/globes
-  local catalog = { 
+  local catalog = {
 	{ Item="xcl_element_bug_gem", ReqItem={"xcl_element_bug_silk","xcl_element_bug_dust"}},
 	{ Item="xcl_element_bug_globe", ReqItem={"xcl_element_bug_silk", "xcl_element_bug_dust", "xcl_element_bug_gem"}},
 	{ Item="xcl_element_dark_gem", ReqItem={"xcl_element_dark_silk","xcl_element_dark_dust"}},
@@ -1085,7 +1102,7 @@ function base_camp_2.Compute_Swap_Catalog()
 	local base_data = COMMON_GEN.TRADES[ii]
 	table.insert(catalog, base_data)
   end
-  
+
   --random trades
   for ii = 1, #SV.base_trades, 1 do
 	local base_data = SV.base_trades[ii]
@@ -1096,26 +1113,26 @@ end
 
 function base_camp_2.Swap_Action(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  
+
   local catalog = base_camp_2.Compute_Swap_Catalog()
-  
+
   local state = 0
   local repeated = false
   local cart = -1 --catalog element chosen to trade for
   local tribute = {} --item IDs chosen to trade in
-  
+
   -- for special case when spoken to after forgetting to hold up their end of the trade, one off gag
   if SV.base_town.ValueTradeItem ~= "" then
     state = 4
 	repeated = true
   end
 
-  
+
   local Prices = { 1000, 5000, 25000 }
   local player = CH('PLAYER')
   local chara = CH('Swap_Owner')
   UI:SetSpeaker(chara)
-  
+
 	while state > -1 do
 		if state == 0 then
 			local msg = STRINGS:Format(STRINGS.MapStrings['Swap_Intro'])
@@ -1171,7 +1188,7 @@ function base_camp_2.Swap_Action(obj, activator)
 					table.insert(tribute, trade.ReqItem[ii])
 				end
 			end
-			
+
 			if free_slots > 0 then
 				UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Give_Choose'], receive_item:GetDisplayName()))
 				--tribute simply aggregates all items period
@@ -1199,15 +1216,15 @@ function base_camp_2.Swap_Action(obj, activator)
 				local give_item = RogueEssence.Dungeon.InvItem(tribute[ii])
 				table.insert(give_items, give_item:GetDisplayName())
 			end
-			
+
 			local itemEntry = _DATA:GetItem(trade.Item)
 			local total = Prices[itemEntry.Rarity]
-			
+
 			UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Confirm_001'], STRINGS:CreateList(give_items), receive_item:GetDisplayName()))
 			UI:ChoiceMenuYesNo(STRINGS:Format(STRINGS.MapStrings['Swap_Confirm_002'], STRINGS:FormatKey("MONEY_AMOUNT", total)), false)
 			UI:WaitForChoice()
 			local result = UI:ChoiceResult()
-			
+
 			if result then
 				for ii = #tribute, 1, -1 do
 					local item_slot = GAME:FindPlayerItem(tribute[ii], true, true)
@@ -1222,19 +1239,19 @@ function base_camp_2.Swap_Action(obj, activator)
 				end
 				SOUND:PlayBattleSE("DUN_Money")
 				GAME:RemoveFromPlayerMoney(total)
-				
-				
+
+
 				--remove the trade if it was a base trade
 				local base_trade_idx = cart - (#catalog - #SV.base_trades)
 				if base_trade_idx > 0 then
 					table.remove(SV.base_trades, base_trade_idx)
 				end
-				
+
 				SV.base_town.ValueTradeItem = trade.Item
 				if itemEntry.Rarity == 3 then
 				  UI:SetSpeakerEmotion("Inspired")
 				  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Complete_Max_001']))
-				  
+
 				  -- sableye gets so obsessed with his treasure he forgets about you, once
 				  if SV.base_town.ValueTraded == false then
 				    UI:SetSpeakerEmotion("Joyous")
@@ -1242,54 +1259,54 @@ function base_camp_2.Swap_Action(obj, activator)
 				    return
 				  end
 				end
-				
+
 				state = 4
 			else
 				state = 1
 			end
-				
+
 		elseif state == 4 then
-			
+
 			local itemEntry = _DATA:GetItem(SV.base_town.ValueTradeItem)
 			if itemEntry.Rarity == 3 then
 			  if SV.base_town.ValueTraded == false then
-			  
+
 			    SOUND:PlayBattleSE("EVT_Emote_Exclaim_2")
 			    GROUND:CharSetEmote(chara, "exclaim", 1)
 			    UI:SetSpeakerEmotion("Stunned")
-			  
+
 			    UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Complete_Max_003']))
 			    UI:SetSpeakerEmotion("Normal")
 			  else
-				
+
 			    UI:SetSpeakerEmotion("Happy")
 			    UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Complete_Max_004']))
 			    UI:SetSpeakerEmotion("Normal")
 			  end
 			  SV.base_town.ValueTraded = true
-			  
+
 			else
 			  UI:SetSpeakerEmotion("Normal")
 			  UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Complete']))
 			end
-			
+
 			local receive_item = RogueEssence.Dungeon.InvItem(SV.base_town.ValueTradeItem)
 			UI:ResetSpeaker()
 			SOUND:PlayFanfare("Fanfare/Treasure")
 			UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Swap_Give'], player:GetDisplayName(), receive_item:GetDisplayName()))
-			
+
 			UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Item_Give_Storage'], receive_item:GetDisplayName()))
 			GAME:GivePlayerStorageItem(SV.base_town.ValueTradeItem, 1, false, "")
-			
+
 			UI:SetSpeaker(chara)
-			
+
 			-- recompute the available trades
 			catalog = base_camp_2.Compute_Swap_Catalog()
 			SV.base_town.ValueTradeItem = ""
-			
+
 			tribute = {}
 			cart = -1
-			
+
 			state = 0
 		end
 	end
@@ -1391,7 +1408,7 @@ function base_camp_2.Music_Action(obj, activator)
   if SV.guildmaster_summit.GameComplete then
     unlocks["GUILDMASTER"] = true
   end
-  
+
   zones = _DATA.DataIndices[RogueEssence.Data.DataManager.DataType.Zone]:GetOrderedKeys(false)
   for zone_idx = 0, zones.Count - 1, 1  do
     zone = zones[zone_idx]
@@ -1399,8 +1416,8 @@ function base_camp_2.Music_Action(obj, activator)
       unlocks["DUN_" .. zone] = true
     end
   end
-  
-  
+
+
   local spoilers = {}
   for key, unlock_reqs in pairs(base_camp_2.music_tbl) do
     contains_unlock = false
@@ -1413,8 +1430,8 @@ function base_camp_2.Music_Action(obj, activator)
       table.insert(spoilers, key)
     end
   end
-  
-  
+
+
   UI:ShowMusicMenu(false, spoilers)
   UI:WaitForChoice()
   local result = UI:ChoiceResult()
@@ -1442,14 +1459,22 @@ end
 
 function base_camp_2.West_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("base_camp", "entrance_east")
+  if((#base_camp_2.junction.west.dungeons == 0) and (#base_camp_2.junction.west.groundmaps == 1)) then
+	GAME:FadeOut(false, 20)
+	GAME:EnterGroundMap("base_camp", "entrance_east")
+  else
+	 COMMON.ShowDestinationMenu(base_camp_2.junction.west.dungeons, base_camp_2.junction.west.groundmaps)
+   end
 end
 
 function base_camp_2.North_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("luminous_spring", "entrance_south")
+  if((#base_camp_2.junction.north.dungeons == 0) and (#base_camp_2.junction.north.groundmaps == 1)) then
+	GAME:FadeOut(false, 20)
+	GAME:EnterGroundMap("luminous_spring", "entrance_south")
+   else
+	  COMMON.ShowDestinationMenu(base_camp_2.junction.north.dungeons, base_camp_2.junction.north.groundmaps)
+   end
 end
 
 function base_camp_2.Post_Office_Entrance_Touch(obj, activator)
@@ -1461,14 +1486,14 @@ end
 function base_camp_2.AssemblyInteract(chara, target)
   GROUND:CharTurnToChar(target, chara)
   UI:SetSpeaker(target)
-  
+
   local mon = _DATA:GetMonster(target.CurrentForm.Species)
   local form = mon.Forms[target.CurrentForm.Form]
-  
+
   local personality = form:GetPersonalityType(target.Data.Discriminator)
-  
+
   local talk_string = nil
-  
+
   --TODO: accept variations of the talkstrings (VAR_XX)
   --look for a talkstring of this species, form, gender
   if talk_string == nil then
@@ -1477,7 +1502,7 @@ function base_camp_2.AssemblyInteract(chara, target)
       talk_string = RogueEssence.Text.StringsEx[var_key]
     end
   end
-  
+
   if talk_string == nil then
     --if talkstring is nil, look for a talkstring of this species, form
 	local var_key = string.format("TALK_REST_%04d_%02d_VAR_00", mon.IndexNum, target.CurrentForm.Form)
@@ -1485,7 +1510,7 @@ function base_camp_2.AssemblyInteract(chara, target)
       talk_string = RogueEssence.Text.StringsEx[var_key]
     end
   end
-  
+
   if talk_string == nil then
     --if talkstring is nil, look for a talkstring of this species
 	local var_key = string.format("TALK_REST_%04d_VAR_00", mon.IndexNum)
@@ -1493,7 +1518,7 @@ function base_camp_2.AssemblyInteract(chara, target)
       talk_string = RogueEssence.Text.StringsEx[var_key]
     end
   end
-  
+
   if talk_string == nil then
     --if talkstring is still nil, fall back to groundinteract
 	COMMON.GroundInteract(chara, target)
@@ -1501,8 +1526,8 @@ function base_camp_2.AssemblyInteract(chara, target)
     --otherwise, print the talkstring
 	UI:WaitShowDialogue(STRINGS:Format(talk_string))
   end
-  
-  
+
+
 end
 
 
@@ -1705,8 +1730,5 @@ function base_camp_2.Assembly40_Action(chara, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
   base_camp_2.AssemblyInteract(activator, chara)
 end
-
-
-
 
 return base_camp_2

--- a/Data/Script/origin/ground/guild_path/init.lua
+++ b/Data/Script/origin/ground/guild_path/init.lua
@@ -2,20 +2,27 @@ require 'origin.common'
 
 local guild_path = {}
 
+-- Tables for the junctions on this map
+guild_path.junction = {}
+
+guild_path.junction.east = {
+  dungeons = {},
+  groundmaps={{Flag=true,Zone="guildmaster_island", ID=1, Entry=2}}
+}
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
 function guild_path.Init(map)
-  DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  PrintInfo("=>> Init_guild_path")
+DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+PrintInfo("=>> Init_guild_path")
 
-  GROUND:RefreshPlayer()
+GROUND:RefreshPlayer()
 end
 
 function guild_path.Enter(map)
-  DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+DEBUG.EnableDbgCoro() --Enable debugging this coroutine
 
-  GAME:FadeIn(20)
+GAME:FadeIn(20)
 end
 
 function guild_path.Update(map, time)
@@ -29,15 +36,20 @@ end
 -- Objects Callbacks
 --------------------------------------------------
 function guild_path.East_Exit_Touch(obj, activator)
-  DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+
+if((#guild_path.junction.east.dungeons == 0) and (#guild_path.junction.east.groundmaps == 1)) then
   GAME:FadeOut(false, 20)
   GAME:EnterGroundMap("base_camp", "entrance_west")
-end
+  else
+    COMMON.ShowDestinationMenu(guild_path.junction.east.dungeons, guild_path.junction.east.groundmaps)
+    end
+    end
 
-function guild_path.Hut_Entrance_Touch(obj, activator)
-  DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("guild_hut", "entrance_south")
-end
+    function guild_path.Hut_Entrance_Touch(obj, activator)
+    DEBUG.EnableDbgCoro() --Enable debugging this coroutine
+    GAME:FadeOut(false, 20)
+    GAME:EnterGroundMap("guild_hut", "entrance_south")
+    end
 
-return guild_path
+    return guild_path

--- a/Data/Script/origin/ground/luminous_spring/init.lua
+++ b/Data/Script/origin/ground/luminous_spring/init.lua
@@ -3,6 +3,15 @@ require 'origin.menu.team.AssemblySelectMenu'
 
 local luminous_spring = {}
 
+-- Tables for the junctions on this map
+luminous_spring.junction = {}
+
+luminous_spring.junction.south =
+{
+	dungeons = {},
+	groundmaps = {{Flag=true,Zone="guildmaster_island", ID=2,Entry=1}}
+}
+
 --------------------------------------------------
 -- Map Callbacks
 --------------------------------------------------
@@ -11,7 +20,7 @@ function luminous_spring.Init(map)
   PrintInfo("=>> Init_luminous_spring")
 
   COMMON.RespawnAllies()
-  
+
 end
 
 function luminous_spring.Enter(map)
@@ -40,24 +49,28 @@ end
 
 function luminous_spring.South_Exit_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
-  GAME:FadeOut(false, 20)
-  GAME:EnterGroundMap("base_camp_2", "entrance_north")
+  if((#luminous_spring.junction.south.dungeons == 0) and (#luminous_spring.junction.south.groundmaps == 1)) then
+	GAME:FadeOut(false, 20)
+    GAME:EnterGroundMap("base_camp_2", "entrance_north")
+   else
+	  COMMON.ShowDestinationMenu(luminous_spring.junction.south.dungeons, luminous_spring.junction.south.groundmaps)
+   end
 end
 
 function luminous_spring.Spring_Touch(obj, activator)
   DEBUG.EnableDbgCoro() --Enable debugging this coroutine
 	UI:ResetSpeaker()
-	
+
 	local state = 0
 	local repeated = false
 	local member = nil
 	local evo = nil
 	local player = CH('PLAYER')
-	
+
 	GAME:CutsceneMode(true)
 	GAME:MoveCamera(300, 152, 90, false)
 	GROUND:TeleportTo(player, 292, 312, Direction.Down)
-	
+
 	if not SV.luminous_spring.Returning then
 		UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Evo_Intro_1']))
 		UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Evo_Intro_2']))
@@ -153,18 +166,18 @@ function luminous_spring.Spring_Touch(obj, activator)
 		elseif state == 3 then
 			--execute evolution
 			local mon = _DATA:GetMonster(evo.Result)
-			
+
 			GROUND:SpawnerSetSpawn("EVO_SUBJECT",member)
 			local subject = GROUND:SpawnerDoSpawn("EVO_SUBJECT")
-			
+
 			GROUND:MoveInDirection(subject, Direction.Up, 60, false, 2)
 			GROUND:EntTurn(subject, Direction.Down)
-			
+
 			UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Evo_Begin']))
-			
+
 			SOUND:PlayBattleSE("EVT_Evolution_Start")
 			GAME:FadeOut(true, 20)
-			
+
 			local pastName = member:GetDisplayName(true)
 			GAME:PromoteCharacter(member, evo, "evo_harmony_scarf")
 			COMMON.RespawnAllies()
@@ -172,28 +185,28 @@ function luminous_spring.Spring_Touch(obj, activator)
 			--GROUND:SpawnerSetSpawn("EVO_SUBJECT",member)
 			subject = GROUND:SpawnerDoSpawn("EVO_SUBJECT")
 			GROUND:TeleportTo(subject, 292, 192, Direction.Down)
-			
+
 			GAME:WaitFrames(30)
-			
+
 			SOUND:PlayBattleSE("EVT_Title_Intro")
 			GAME:FadeIn(20)
 			SOUND:PlayFanfare("Fanfare/Promotion")
-			
-			
+
+
 			UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Evo_Complete'], pastName, mon:GetColoredName()))
 			GAME:CheckLevelSkills(member, 0)
 			if member.Level > 1 then
 				GAME:CheckLevelSkills(member, member.Level-1)
 			end
-			
+
 			GROUND:MoveInDirection(subject, Direction.Down, 60, false, 2)
-			
+
 			GROUND:RemoveCharacter("EvoSubject")
-			
+
 			state = 0
 		end
 	end
-	
+
 	GAME:MoveCamera(0, 0, 90, true)
 	GAME:CutsceneMode(false)
 end
@@ -236,13 +249,13 @@ function luminous_spring.SpecialEvent(cur_date)
   GROUND:TeleportTo(player, temp_char.MapLoc.X, temp_char.MapLoc.Y + 48, Direction.Up)
   GAME:WaitFrames(20)
   GAME:FadeIn(60)
-  
+
   SOUND:PlayBattleSE("EVT_Emote_Exclaim_2")
   GROUND:CharSetEmote(player, "exclaim", 1)
   GROUND:CharSetEmote(temp_char, "exclaim", 1)
-  
+
   GAME:WaitFrames(20)
-  
+
   UI:SetSpeaker(temp_char)
   UI:SetSpeakerEmotion("Surprised")
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Special_Event_001']))
@@ -251,17 +264,17 @@ function luminous_spring.SpecialEvent(cur_date)
     UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Special_Event_002']))
   end
   UI:WaitShowDialogue(STRINGS:Format(STRINGS.MapStrings['Special_Event_003']))
-  
+
   local recruit = _DATA.Save.ActiveTeam:CreatePlayer(_DATA.Save.Rand, base_form, 10, "", 0)
   local talk_evt = RogueEssence.Dungeon.BattleScriptEvent("AllyInteract")
   recruit.ActionEvents:Add(talk_evt)
   COMMON.JoinTeamWithFanfare(recruit, false)
-  
+
   GAME:FadeOut(false, 30)
   current_ground:RemoveTempChar(temp_char)
   GAME:CutsceneMode(false)
   GAME:FadeIn(30)
-  
+
   SV.secret.Time = true
 end
 


### PR DESCRIPTION
Extension of the previous PR to add the ability for mods to patch dungeons into junctions. This now allows other warps to be modified in the same way, while still keeping their vanilla behavior of just warping the player if no other locations have been added.

I modified all of the maps that I could think of that a modder might want to modify. These are:
* base_camp
* base_camp_2
* luminous_spring
* guild_trail